### PR TITLE
Add the following CLI commands:

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,15 @@ Avoid specifying "--runtime=amd" option with the "docker run" command by setting
 ```text
 > amd-ctk runtime configure --runtime=docker --set-as-default
 ```
+
+5. Remove AMD container runtime as default runtime.
+
+```text
+> amd-ctk runtime configure --runtime=docker --unset-as-default
+```
+
+6. Remove AMD container runtime configuration in Docker. (undo the earlier configuration)
+
+``` text
+> amd-ctk runtime configure --runtime=docker --remove
+```

--- a/cmd/amd-ctk/runtime/engine/engine.go
+++ b/cmd/amd-ctk/runtime/engine/engine.go
@@ -18,5 +18,7 @@ package engine
 
 type Interface interface {
 	ConfigRuntime(string, string, bool) error
+	UnsetDefaultRuntime() error
 	Update(string) (int, error)
+	RemoveRuntime(string) error
 }


### PR DESCRIPTION
amd-ctk runtime configure

--remove                                    remove from target runtimes
(default: false)

--unset-amd-as-default, --unset-as-default  remove AMD runtime as the default (default: false)