### PR TITLE
Fix for https://ontrack-internal.amd.com/browse/GPUAI-4921

### DIFF
--- a/cmd/amd-ctk/runtime/configure/configure.go
+++ b/cmd/amd-ctk/runtime/configure/configure.go
@@ -109,6 +109,7 @@ func performAction(c *cli.Context, cfgOptions *configOptions) error {
 	var (
 		err           error
 		runtimeEngine engine.Interface
+		doNotUpdate   bool
 	)
 
 	switch cfgOptions.runtime {
@@ -130,7 +131,7 @@ func performAction(c *cli.Context, cfgOptions *configOptions) error {
 		}
 	} else {
 		if cfgOptions.remove {
-			err = runtimeEngine.RemoveRuntime(defaultAmdRuntimeName)
+			err, doNotUpdate = runtimeEngine.RemoveRuntime(defaultAmdRuntimeName)
 		} else {
 			err = runtimeEngine.ConfigRuntime(defaultAmdRuntimeName, defaultAmdRuntimeExecutable, cfgOptions.setAsDefault)
 		}
@@ -141,14 +142,16 @@ func performAction(c *cli.Context, cfgOptions *configOptions) error {
 	}
 
 	// Save the config
-	num, err := runtimeEngine.Update(cfgOptions.configFilepath)
-	if err != nil {
-		return fmt.Errorf("failed to save the config: %v", err)
-	}
+	if !doNotUpdate {
+		num, err := runtimeEngine.Update(cfgOptions.configFilepath)
+		if err != nil {
+			return fmt.Errorf("failed to save the config: %v", err)
+		}
 
-	if num != 0 {
-		fmt.Printf("Updated the config file: %v\n", cfgOptions.configFilepath)
+		if num != 0 {
+			fmt.Printf("Updated the config file: %v\n", cfgOptions.configFilepath)
+		}
+		fmt.Printf("Please restart %v daemon\n", cfgOptions.runtime)
 	}
-	fmt.Printf("Please restart %v daemon\n", cfgOptions.runtime)
 	return nil
 }

--- a/cmd/amd-ctk/runtime/engine/docker/docker.go
+++ b/cmd/amd-ctk/runtime/engine/docker/docker.go
@@ -111,11 +111,15 @@ func (d *dockerConfig) UnsetDefaultRuntime() error {
 	return nil
 }
 
-func (d *dockerConfig) RemoveRuntime(name string) error {
+// RemoveRuntime removes the amd runtime configuration and returns
+// an error and a do not update flag in case daemon.json doesn't need
+// to be updated
+func (d *dockerConfig) RemoveRuntime(name string) (error, bool) {
 	if d == nil {
-		return fmt.Errorf("configuration is empty")
+		return fmt.Errorf("configuration is empty"), true
 	}
 
+	updated := false
 	currentCfg := *d
 
 	//check any existing "runtimes"
@@ -133,10 +137,14 @@ func (d *dockerConfig) RemoveRuntime(name string) error {
 		if len(runtimes) == 0 {
 			delete(currentCfg, runtimesKey)
 		}
+		updated = true
 	}
 
-	*d = currentCfg
-	return nil
+	if updated {
+		*d = currentCfg
+		return nil, false
+	}
+	return nil, true
 }
 
 func (d dockerConfig) Update(path string) (int, error) {

--- a/cmd/amd-ctk/runtime/engine/engine.go
+++ b/cmd/amd-ctk/runtime/engine/engine.go
@@ -20,5 +20,5 @@ type Interface interface {
 	ConfigRuntime(string, string, bool) error
 	UnsetDefaultRuntime() error
 	Update(string) (int, error)
-	RemoveRuntime(string) error
+	RemoveRuntime(string) (error, bool)
 }


### PR DESCRIPTION
in case of 'amd-ctk runtime configure --runtime=docker --remove' do not create an empty daemon.json file in case the file doesn't exist in the first place and no update has been made.