### PR TITLE
Update rpmbuild.spec to use a variable for container_workdir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ CUR_USER:=$(shell whoami)
 CUR_TIME:=$(shell date +%Y-%m-%d_%H.%M.%S)
 CONTAINER_NAME:=${CUR_USER}_container_toolkit-bld
 RPM_CONTAINER_NAME:=${CUR_USER}_container_toolkit-rpm-bld
-CONTAINER_WORKDIR := /usr/src/github.com/ROCm/container-toolkit
+CONTAINER_WORKDIR ?= /usr/src/github.com/ROCm/container-toolkit
 
 TOP_DIR := $(PWD)
 GOINSECURE='github.com, google.golang.org, golang.org'
@@ -148,7 +148,7 @@ deb-pkg-build: all
 
 .PHONY: rpm-pkg-build
 rpm-pkg-build: all
-	rpmbuild -bb $(CURDIR)/build/rpmbuild.spec
+	CONTAINER_WORKDIR=$(CONTAINER_WORKDIR) rpmbuild -bb $(CURDIR)/build/rpmbuild.spec
 	cp $(HOME)/rpmbuild/RPMS/x86_64/*.rpm $(CURDIR)/bin/
 
 .PHONY: pkg-rpm pkg-rpm-clean

--- a/build/rpmbuild.spec
+++ b/build/rpmbuild.spec
@@ -12,7 +12,7 @@ BuildArch: x86_64
 This package contains pre-built binaries for AMD containter toolkit
 
 %install
-base_dir=/usr/src/github.com/ROCm/container-toolkit
+base_dir=${CONTAINER_WORKDIR}
 install -D -m 0755 ${base_dir}/bin/rpmbuild/amd-ctk  %{buildroot}/usr/bin/amd-ctk
 install -D -m 0755 ${base_dir}/bin/rpmbuild/amd-container-runtime  %{buildroot}/usr/bin/amd-container-runtime
 install -D -m 0644 ${base_dir}/README.md %{buildroot}/usr/share/doc/my-binary-package/README.md


### PR DESCRIPTION
This is to ensure the path for container_workdir can be overriden