### PR TITLE
Enclose user and group names in quotes

### DIFF
--- a/tools/deb/base-image/Makefile
+++ b/tools/deb/base-image/Makefile
@@ -1,13 +1,13 @@
 all:
 	@if [ -n "$(INSECURE_REGISTRY)" ]; then \
 	echo "building dev container with insecure registry" ;\
-	docker build --build-arg USER=$(shell id -un) --build-arg GROUP=$(shell id -gn) \
+	docker build --build-arg USER="$(shell id -un)" --build-arg GROUP="$(shell id -gn)" \
 		--build-arg BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE) \
 		--build-arg INSECURE_REGISTRY=$(INSECURE_REGISTRY) \
 		--build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t ${BUILD_CONTAINER} . ;\
 	else \
 	echo "building dev container without insecure registry" ;\
-	docker build --build-arg USER=$(shell id -un) --build-arg GROUP=$(shell id -gn) \
+	docker build --build-arg USER="$(shell id -un)" --build-arg GROUP="$(shell id -gn)" \
 		--build-arg BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE) \
 		--build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t ${BUILD_CONTAINER} . ;\
 	fi

--- a/tools/rpmbuild/base-image/Makefile
+++ b/tools/rpmbuild/base-image/Makefile
@@ -1,13 +1,13 @@
 all:
 	@if [ -n "$(INSECURE_REGISTRY)" ]; then \
 	echo "building rpmbuild dev container with insecure registry" ;\
-	docker build --build-arg USER=$(shell id -un) --build-arg GROUP=$(shell id -gn) \
+	docker build --build-arg USER="$(shell id -un)" --build-arg GROUP="$(shell id -gn)" \
 		--build-arg BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE) \
 		--build-arg INSECURE_REGISTRY=$(INSECURE_REGISTRY) \
 		--build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t ${RPM_BUILD_CONTAINER} . ;\
 	else \
 	echo "building rpmbuild dev container without insecure registry" ;\
-	docker build --build-arg USER=$(shell id -un) --build-arg GROUP=$(shell id -gn) \
+	docker build --build-arg USER="$(shell id -un)" --build-arg GROUP="$(shell id -gn)" \
 		--build-arg BUILD_BASE_IMAGE=$(BUILD_BASE_IMAGE) \
 		--build-arg UID=$(shell id -u) --build-arg GID=$(shell id -g) -t ${RPM_BUILD_CONTAINER} . ;\
 	fi


### PR DESCRIPTION
This is to ensure user/group names with spaces are treated as a single argument