### PR TITLE
Add postrm script for clean uninstallation

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To install the AMD Container Toolkit from the official repository, follow these 
 1. Configure the AMD container runtime for Docker as follows. The following command modifies the docker configuration file, /etc/docker/daemon.json, so that Docker can use the AMD container runtime.
 
      ```text
-     > sudo amd-ctk configure runtime
+     > sudo amd-ctk runtime configure
      ```
 
 2. Restart the Docker daemon.

--- a/build/debian/DEBIAN/postrm
+++ b/build/debian/DEBIAN/postrm
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -e
+
+AMD_CONTAINER_RUNTIME=/usr/local/bin/amd-container-runtime
+AMD_CONTAINER_TOOLKIT=/usr/local/bin/amd-ctk
+
+case "$1" in
+    purge)
+        [ -e "${AMD_CONTAINER_TOOLKIT}" ] && rm "${AMD_CONTAINER_TOOLKIT}"
+        [ -e "${AMD_CONTAINER_RUNTIME}" ] && rm "${AMD_CONTAINER_RUNTIME}"
+    ;;
+
+    upgrade|failed-upgrade|remove|abort-install|abort-upgrade|disappear)
+    ;;
+
+    *)
+        echo "postrm called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0
+


### PR DESCRIPTION
While trying to uninstall the amd-container-toolkit package, a warning is displayed - '/usr/local' not empty so not removed

postrm script ensures clean uninstallation

PR to main - https://github.com/ROCm/container-toolkit/pull/32