### PR TITLE
Quickstart update and docker compose usage

### DIFF
--- a/docs/container-runtime/docker-compose.rst
+++ b/docs/container-runtime/docker-compose.rst
@@ -1,0 +1,95 @@
+Docker Compose Usage
+====================
+
+The AMD Container Toolkit can be used with Docker Compose, enabling GPU access in multi-container applications.
+
+Prerequisites
+-------------
+
+Before using this guide, ensure you have:
+
+1. Completed the AMD Container Toolkit installation as described in the Quick Start Guide.
+2. Docker Compose installed (v2 or higher recommended).
+3. Docker engine properly configured with the AMD runtime.
+
+Example Docker Compose Configuration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Below is a basic example of a Docker Compose file configured to use AMD GPUs:
+
+.. code-block:: yaml
+
+   version: '3'
+   services:
+     pytorch:
+       image: rocm/pytorch
+       runtime: amd
+       environment:
+         - AMD_VISIBLE_DEVICES=all
+       command: python -c "import torch; print('GPU available:', torch.cuda.is_available()); print('Number of GPUs:', torch.cuda.device_count())"
+
+The key elements in this configuration are:
+
+1. **runtime: amd** - Specifies that the AMD Container Runtime should be used for this service.
+2. **AMD_VISIBLE_DEVICES** - Controls which GPUs are visible to the container.
+
+GPU Visibility Control
+----------------------
+
+Control GPU visibility through environment variables. The `AMD_VISIBLE_DEVICES` variable can be set to:
+
+- **AMD_VISIBLE_DEVICES=all** - Makes all GPUs visible to the container
+- **AMD_VISIBLE_DEVICES=0,1** - Makes only GPU indices 0 and 1 visible
+- **AMD_VISIBLE_DEVICES=none** - Disables GPU visibility
+
+When using Docker Compose to orchestrate multiple containers, you can specify the GPU resources for each service independently.
+For example, if you have a training service and an inference service, you can assign different GPUs to each:
+
+.. code-block:: yaml
+
+   version: '3'
+   services:
+     training:
+       image: rocm/tensorflow
+       runtime: amd
+       environment:
+         - AMD_VISIBLE_DEVICES=0
+
+     inference:
+       image: rocm/pytorch
+       runtime: amd
+       environment:
+         - AMD_VISIBLE_DEVICES=1
+
+Converting Existing Docker Compose Files
+----------------------------------------
+
+If you have existing Docker Compose files using NVIDIA GPUs or other GPU setups, use these guidelines to migrate to the AMD Container Toolkit:
+
+1. Replace runtime specifications:
+
+   .. code-block:: diff
+
+      - runtime: nvidia
+      + runtime: amd
+
+2. Update environment variables:
+
+   .. code-block:: diff
+
+      - NVIDIA_VISIBLE_DEVICES: all
+      + AMD_VISIBLE_DEVICES: all
+
+      - HIP_VISIBLE_DEVICES: 0,1
+      + AMD_VISIBLE_DEVICES: 0,1
+
+3. Remove explicit device mappings if present (not needed with AMD Container Toolkit):
+
+   .. code-block:: diff
+
+      services:
+        myservice:
+          # Remove these lines
+          - devices:
+          -   - /dev/kfd
+          -   - /dev/dri

--- a/docs/container-runtime/index.rst
+++ b/docs/container-runtime/index.rst
@@ -10,4 +10,5 @@ Welcome to the official documentation for the AMD Container Toolkit!
 - :doc:`troubleshooting`
 - :doc:`migration-guide`
 - :doc:`developer-guide`
+- :doc:`docker-compose`
 - :doc:`release-notes`

--- a/docs/container-runtime/quick-start-guide.rst
+++ b/docs/container-runtime/quick-start-guide.rst
@@ -125,26 +125,34 @@ Step 6: Verify Container Runtime Installation
 
 To run Docker containers with access to AMD GPUs, you need to specify the AMD runtime and visible GPUs. Here are some examples you can use to verify the installation:
 
-**Run a container with access to all available AMD GPUs:**
+Run a container with access to all available AMD GPUs:
 
 .. code-block:: bash
    docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all --runtime=amd rocm/rocm-terminal amd-smi monitor
-   GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
-      0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      2  138 W   42 °C   34 °C   145 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      3  141 W   39 °C   33 °C   139 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      4  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      5  137 W   38 °C   33 °C   133 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-      7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
-**To run a container with access to a specific AMD GPU (i.e., the first GPU):**
+Output should look like this, validating that all GPUs are visible:
+
+.. code-block:: bash   
+   GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
+     0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     2  138 W   42 °C   34 °C   145 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     3  141 W   39 °C   33 °C   139 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     4  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     5  137 W   38 °C   33 °C   133 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+
+Tun a container with access to a specific AMD GPU (i.e., the first GPU):
 
 .. code-block:: bash
    docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 --runtime=amd rocm/rocm-terminal amd-smi monitor
+
+Output should look like this, validating that only the first GPU is visible:
+
+.. code-block:: bash   
    GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
-      0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+     0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
 Uninstallation Guide
 --------------------

--- a/docs/container-runtime/quick-start-guide.rst
+++ b/docs/container-runtime/quick-start-guide.rst
@@ -10,23 +10,23 @@ Before installing the AMD Container Toolkit, ensure the following dependencies a
 
 **Docker** - The toolkit is designed to work with Docker, so ensure you have Docker installed on your system. the **Docker version must be 25 or above**. The Container Device Interface (CDI) format, used by modern container runtimes to abstract and expose GPUs, is not supported in older Docker versions. Without Docker 25+, CDI functionality such as dynamic device enumeration and CDI-style run commands will not work as intended.
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      sudo apt-get install docker.io
+   sudo apt-get install docker.io
 
 You can verify your Docker version using:
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      docker --version
+   docker --version
 
 If you are on an earlier Docker version, please upgrade to at least Docker 25 before proceeding with toolkit configuration and GPU-based workloads.      
 
 **jq** - Required during uninstallation to parse configuration settings cleanly.
 
-   .. code-block:: bash
+.. code-block:: bash
 
-      sudo apt-get install jq
+   sudo apt-get install jq
 
 Step 1: Update System and Group Settings
 ----------------------------------------
@@ -126,23 +126,25 @@ Step 6: Verify Container Runtime Installation
 To run Docker containers with access to AMD GPUs, you need to specify the AMD runtime and visible GPUs. Here are some examples you can use to verify the installation:
 
 **Run a container with access to all available AMD GPUs:**
-  .. code-block:: bash
-     docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all --runtime=amd rocm/rocm-terminal amd-smi monitor
-      GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
-        0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        2  138 W   42 °C   34 °C   145 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        3  141 W   39 °C   33 °C   139 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        4  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        5  137 W   38 °C   33 °C   133 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
-        7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+
+.. code-block:: bash
+   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all --runtime=amd rocm/rocm-terminal amd-smi monitor
+   GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
+      0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      2  138 W   42 °C   34 °C   145 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      3  141 W   39 °C   33 °C   139 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      4  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      5  137 W   38 °C   33 °C   133 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+      7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
 **To run a container with access to a specific AMD GPU (i.e., the first GPU):**
-  .. code-block:: bash
-     docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 --runtime=amd rocm/rocm-terminal amd-smi monitor
-     GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
-       0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+
+.. code-block:: bash
+   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 --runtime=amd rocm/rocm-terminal amd-smi monitor
+   GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
+      0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
 Uninstallation Guide
 --------------------

--- a/docs/container-runtime/quick-start-guide.rst
+++ b/docs/container-runtime/quick-start-guide.rst
@@ -8,7 +8,7 @@ Prerequisites
 
 Before installing the AMD Container Toolkit, ensure the following dependencies are installed.
 
-**Docker** - The toolkit is designed to work with Docker, so ensure you have Docker installed on your system. the **Docker version must be 25 or above**. The Container Device Interface (CDI) format, used by modern container runtimes to abstract and expose GPUs, is not supported in older Docker versions. Without Docker 25+, CDI functionality such as dynamic device enumeration and CDI-style run commands will not work as intended.
+**Docker** - The toolkit is designed to work with Docker, so ensure you have Docker installed on your system. The **Docker version must be 25 or above**. The Container Device Interface (CDI) format, used by modern container runtimes to abstract and expose GPUs, is not supported in older Docker versions. Without Docker 25+, CDI functionality such as dynamic device enumeration and CDI-style run commands will not work as intended.
 
 .. code-block:: bash
 
@@ -45,8 +45,8 @@ Step 1: Update System and Group Settings
 Step 2: Install the AMDGPU Driver
 ---------------------------------
 
-- Refer to the latest ROCm documentation for driver installation here, [ROCm Install Quick Start](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html).
-- Download the AMDGPU driver installer package from the [Radeon Repository](https://repo.radeon.com/amdgpu-install).
+- Refer to the latest ROCm documentation for driver installation here, `ROCm Install Quick Start <https://rocm.docs.amd.com/projects/install-on-linux/en/latest/install/quick-start.html>`_.
+- Download the AMDGPU driver installer package from the `Radeon Repository <https://repo.radeon.com/amdgpu-install>`_.
 - Install the downloaded package.
 - Load the driver.
 
@@ -69,7 +69,7 @@ Step 3: Configure Repositories
    sudo apt update
    sudo apt install vim wget gpg
 
-- Create keyrings directory
+- Create keyrings directory:
 
 .. code-block:: bash
 
@@ -128,11 +128,13 @@ To run Docker containers with access to AMD GPUs, you need to specify the AMD ru
 Run a container with access to all available AMD GPUs:
 
 .. code-block:: bash
-   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all --runtime=amd rocm/rocm-terminal amd-smi monitor
+
+   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all rocm/rocm-terminal amd-smi monitor
 
 Output should look like this, validating that all GPUs are visible:
 
-.. code-block:: bash   
+.. code-block:: bash
+
    GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
      0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
      1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
@@ -143,14 +145,16 @@ Output should look like this, validating that all GPUs are visible:
      6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
      7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
-Tun a container with access to a specific AMD GPU (i.e., the first GPU):
+Run a container with access to a specific AMD GPU (i.e., the first GPU):
 
 .. code-block:: bash
-   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 --runtime=amd rocm/rocm-terminal amd-smi monitor
+
+   docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 rocm/rocm-terminal amd-smi monitor
 
 Output should look like this, validating that only the first GPU is visible:
 
-.. code-block:: bash   
+.. code-block:: bash
+
    GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
      0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 

--- a/docs/container-runtime/quick-start-guide.rst
+++ b/docs/container-runtime/quick-start-guide.rst
@@ -6,16 +6,30 @@ This section provides a step-by-step guide to install the AMD Container Toolkit 
 Prerequisites
 -------------
 
-Before installing the AMD Container Toolkit, ensure the following dependencies are installed:
+Before installing the AMD Container Toolkit, ensure the following dependencies are installed.
 
-1. **jq** - Required during uninstallation to parse configuration settings cleanly.
+**Docker** - The toolkit is designed to work with Docker, so ensure you have Docker installed on your system. the **Docker version must be 25 or above**. The Container Device Interface (CDI) format, used by modern container runtimes to abstract and expose GPUs, is not supported in older Docker versions. Without Docker 25+, CDI functionality such as dynamic device enumeration and CDI-style run commands will not work as intended.
+
+   .. code-block:: bash
+
+      sudo apt-get install docker.io
+
+You can verify your Docker version using:
+
+   .. code-block:: bash
+
+      docker --version
+
+If you are on an earlier Docker version, please upgrade to at least Docker 25 before proceeding with toolkit configuration and GPU-based workloads.      
+
+**jq** - Required during uninstallation to parse configuration settings cleanly.
 
    .. code-block:: bash
 
       sudo apt-get install jq
 
-Step 1: Install System Prerequisites
-------------------------------------
+Step 1: Update System and Group Settings
+----------------------------------------
 - Update your system:
 
 .. code-block:: bash
@@ -65,7 +79,6 @@ Step 3: Configure Repositories
 
 .. code-block:: bash
 
-   sudo mkdir --parents --mode=0755 /etc/apt/keyrings
    wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | gpg --dearmor | sudo tee /etc/apt/keyrings/rocm.gpg > /dev/null
 
 - Add the AMD Container Toolkit repository.
@@ -74,13 +87,13 @@ Ubuntu 22.04:
 
 .. code-block:: bash
 
-   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amd-container-toolkit/apt/1.2.0 jammy main" | sudo tee /etc/apt/sources.list.d/amd-container-toolkit.list
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amd-container-toolkit/apt/ jammy main" | sudo tee /etc/apt/sources.list.d/amd-container-toolkit.list
 
 Ubuntu 24.04:
 
 .. code-block:: bash
 
-   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amd-container-toolkit/apt/1.2.0 noble main" | sudo tee /etc/apt/sources.list.d/amd-container-toolkit.list
+   echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/amd-container-toolkit/apt/ noble main" | sudo tee /etc/apt/sources.list.d/amd-container-toolkit.list
 
 - Update package index and install the toolkit:
 
@@ -94,20 +107,6 @@ Step 4: Install Toolkit and Docker
 .. code-block:: bash
 
    sudo apt install amd-container-toolkit
-   #Install Docker (if not already installed)
-   sudo apt install docker.io
-
-.. important::
-
-   Please note — the **Docker version must be 25 or above**. The Container Device Interface (CDI) format, used by modern container runtimes to abstract and expose GPUs, is not supported in older Docker versions. Without Docker 25+, CDI functionality such as dynamic device enumeration and CDI-style run commands will not work as intended.
-
-   You can verify your Docker version using:
-
-   .. code-block:: bash
-
-      docker --version
-
-If you are on an earlier Docker version, please upgrade to at least Docker 25 before proceeding with toolkit configuration and GPU-based workloads.
 
 Step 5: Configure Docker Runtime for AMD GPUs
 ---------------------------------------------
@@ -120,6 +119,30 @@ Step 5: Configure Docker Runtime for AMD GPUs
    sudo systemctl restart docker
 
 This configuration ensures that Docker is aware of the AMD container runtime and is able to support GPU-accelerated workloads using AMD Instinct devices.
+
+Step 6: Verify Container Runtime Installation
+---------------------------------------------
+
+To run Docker containers with access to AMD GPUs, you need to specify the AMD runtime and visible GPUs. Here are some examples you can use to verify the installation:
+
+**Run a container with access to all available AMD GPUs:**
+  .. code-block:: bash
+     docker run --runtime=amd -e AMD_VISIBLE_DEVICES=all --runtime=amd rocm/rocm-terminal amd-smi monitor
+      GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
+        0  137 W   41 °C   36 °C   142 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        1  139 W   39 °C   33 °C   135 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        2  138 W   42 °C   34 °C   145 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        3  141 W   39 °C   33 °C   139 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        4  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        5  137 W   38 °C   33 °C   133 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        6  139 W   43 °C   36 °C   151 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+        7  137 W   41 °C   34 °C   141 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
+
+**To run a container with access to a specific AMD GPU (i.e., the first GPU):**
+  .. code-block:: bash
+     docker run --runtime=amd -e AMD_VISIBLE_DEVICES=0 --runtime=amd rocm/rocm-terminal amd-smi monitor
+     GPU  POWER   GPU_T   MEM_T   GFX_CLK   GFX%   MEM%   ENC%   DEC%      VRAM_USAGE
+       0  140 W   42 °C   36 °C   146 MHz    0 %    0 %    N/A    0 %    0.3/192.0 GB
 
 Uninstallation Guide
 --------------------

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -20,5 +20,7 @@ subtrees:
           title: Migration Guide
         - file: container-runtime/developer-guide.rst
           title: Developer Guide
+        - file: container-runtime/docker-compose.rst
+          title: Docker Compose Usage          
         - file: container-runtime/release-notes.rst
           title: Release Notes


### PR DESCRIPTION
This PR contains these updates:

- `quick-start-guide.rst` - Added docker to the prerequisites section, fixed broken `amd-container-toolkit.list` files, added a step to verify installation is working
- `docker-compose.rst` - Instructions and examples for using the container toolkit with docker compose