### PR TITLE
Add CLI to Print Version, Validate CDI Spec, Support for Range Operator and Update README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOINSECURE='github.com, google.golang.org, golang.org'
 GOFLAGS ='-buildvcs=false'
 BUILD_DATE ?= $(shell date   +%Y-%m-%dT%H:%M:%S%z)
 GIT_COMMIT ?= $(shell git rev-list -1 HEAD --abbrev-commit)
-VERSION ?=$(RELEASE)
+VERSION ?= $(shell git describe --tags --always --dirty)
 
 export ${GOROOT}
 export ${GOPATH}

--- a/README.md
+++ b/README.md
@@ -69,12 +69,24 @@ To install the AMD Container Toolkit from the official repository, follow these 
           > docker run --rm --runtime=amd -e AMD_VISIBLE_DEVICES=0,1,2 rocm/rocm-terminal rocm-smi
           ```
 
+          - To use many contiguously numbered GPUs,
+
+          ```text
+          > docker run --rm --runtime=amd -e AMD_VISIBLE_DEVICES=0-3,5,8 rocm/rocm-terminal rocm-smi
+          ```
+
      2. Using [CDI](https://github.com/cncf-tags/container-device-interface) style
 
           - First, generate the CDI spec.
 
           ```text
           > amd-ctk cdi generate --output=/etc/cdi/amd.json
+          ```
+
+          - Validate the generated CDI spec.
+
+          ```text
+          > amd-ctk cdi validate --path=/etc/cdi/amd.json
           ```
 
           - To use all available GPUs,
@@ -147,12 +159,14 @@ amd.com/gpu=0
 To build debian package, use the following command.
 
 ```text
+make
 make pkg-deb
 ```
 
 To build rpm package, use the following command.
 
 ```text
+make
 make pkg-rpm
 ```
 

--- a/cmd/amd-ctk/cdi/cdi.go
+++ b/cmd/amd-ctk/cdi/cdi.go
@@ -19,6 +19,7 @@ package cdi
 import (
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/cdi/generate"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/cdi/list"
+	"github.com/ROCm/container-toolkit/cmd/amd-ctk/cdi/validate"
 	"github.com/urfave/cli/v2"
 )
 
@@ -32,6 +33,7 @@ func AddNewCommand() *cli.Command {
 	cdiCmd.Subcommands = []*cli.Command{
 		list.AddNewCommand(),
 		generate.AddNewCommand(),
+		validate.AddNewCommand(),
 	}
 
 	return &cdiCmd

--- a/cmd/amd-ctk/cdi/validate/validate.go
+++ b/cmd/amd-ctk/cdi/validate/validate.go
@@ -1,0 +1,97 @@
+/**
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package validate
+
+import (
+	"fmt"
+	"os/user"
+	"path/filepath"
+	"strings"
+
+	"github.com/ROCm/container-toolkit/internal/cdi"
+	"github.com/urfave/cli/v2"
+)
+
+const (
+	defaultCDISpecPath = "/etc/cdi"
+	defaultCDISpecFile = "amd.json"
+)
+
+type validateOptions struct {
+	cdiSpecPath string
+}
+
+func AddNewCommand() *cli.Command {
+	// Add the cdi validate command
+	valOptions := validateOptions{}
+	cdiValidateCmd := cli.Command{
+		Name:  "validate",
+		Usage: "Validate the CDI spec for GPUs",
+		Before: func(c *cli.Context) error {
+			return validateValOptions(c, &valOptions)
+		},
+		Action: func(c *cli.Context) error {
+			return performAction(c, &valOptions)
+		},
+	}
+
+	cdiValidateCmd.Flags = []cli.Flag{
+		&cli.StringFlag{
+			Name:        "path",
+			Usage:       "full path of CDI spec file",
+			Value:       defaultCDISpecPath + "/" + defaultCDISpecFile,
+			Destination: &valOptions.cdiSpecPath,
+		},
+	}
+
+	return &cdiValidateCmd
+}
+
+func validateValOptions(c *cli.Context, valOptions *validateOptions) error {
+	curUser, err := user.Current()
+	if err != nil || curUser.Uid != "0" {
+		return fmt.Errorf("Permission denied: Not running as root")
+	}
+
+	out, err := filepath.Abs(valOptions.cdiSpecPath)
+	if err != nil {
+		return fmt.Errorf("Incorrect CDI spec file, Error: %v", err)
+	}
+
+	f := filepath.Base(out)
+	if f != defaultCDISpecFile {
+		return fmt.Errorf("CDI spec file name must be amd.json")
+	}
+
+	valOptions.cdiSpecPath = strings.TrimSuffix(out, f)
+	return nil
+}
+
+func performAction(c *cli.Context, valOptions *validateOptions) error {
+	cdi, err := cdi.New(valOptions.cdiSpecPath)
+	if err != nil {
+		return fmt.Errorf("Failed to create CDI handler, Error: %v", err)
+	}
+
+	// Validate CDI spec
+	err = cdi.ValidateSpec()
+	if err != nil {
+		return fmt.Errorf("Failed to validate CDI spec")
+	}
+
+	return nil
+}

--- a/cmd/amd-ctk/main.go
+++ b/cmd/amd-ctk/main.go
@@ -26,6 +26,25 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
+var (
+	Version   = "dev"
+	BuildDate = "unknown"
+	GitCommit = "none"
+)
+
+func showVersion() *cli.Command {
+	showVersionCmd := cli.Command{
+		Name:  "version",
+		Usage: "Show the version",
+		Action: func(c *cli.Context) error {
+			fmt.Printf("Version: %s\nBuild Date: %s\nGitCommit: %s\n", Version, BuildDate, GitCommit)
+			return nil
+		},
+	}
+
+	return &showVersionCmd
+}
+
 func main() {
 	logger.Init(false)
 
@@ -38,6 +57,7 @@ func main() {
 
 	// Add subcommands
 	amdCtkCli.Commands = []*cli.Command{
+		showVersion(),
 		runtime.AddNewCommand(),
 		cdi.AddNewCommand(),
 	}

--- a/internal/cdi/cdi_test.go
+++ b/internal/cdi/cdi_test.go
@@ -65,6 +65,9 @@ func TestInterface(t *testing.T) {
 	err = cdi.WriteSpec()
 	Assert(t, err == nil, fmt.Sprintf("WriteSpec() returned error %v", err))
 
+	err = cdi.ValidateSpec()
+	Assert(t, err == nil, fmt.Sprintf("ValidateSpec() returned error %v", err))
+
 	cdi.PrintSpec()
 }
 

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -151,11 +151,39 @@ func (oci *oci_t) getAMDEnv() {
 			return dl
 		}
 
+		invalidDevsRange := []string{}
+		invalidDevs := []string{}
 		for _, c := range strings.Split(devs, ",") {
-			i, err := strconv.Atoi(c)
-			if err == nil && i >= 0 {
-				dl = append(dl, i)
+			if strings.Contains(c, "-") {
+				devsRange := strings.SplitN(c, "-", 2)
+				start, err0 := strconv.Atoi(devsRange[0])
+				end, err1 := strconv.Atoi(devsRange[1])
+				if err0 != nil || err1 != nil || start < 0 ||
+					end < 0 || start > end {
+					invalidDevsRange = append(invalidDevsRange, c)
+				} else {
+					for i := start; i <= end; i++ {
+						dl = append(dl, i)
+					}
+				}
+			} else {
+				i, err := strconv.Atoi(c)
+				if err == nil {
+					if i >= 0 {
+						dl = append(dl, i)
+					} else {
+						invalidDevs = append(invalidDevs, c)
+					}
+				}
 			}
+		}
+
+		if len(invalidDevsRange) > 0 {
+			fmt.Printf("Ignoring %v GPUs Ranges as they are invalid\n", invalidDevsRange)
+		}
+
+		if len(invalidDevs) > 0 {
+			fmt.Printf("Ignoring %v GPUs as they are not available\n", invalidDevs)
 		}
 
 		sort.Ints(dl)


### PR DESCRIPTION
What this PR Does:

- Add Support for Range Operator in AMD_VISIBLE_DEVICES
> `docker run --rm --runtime=amd -e AMD_VISIBLE_DEVICES=0-3,5,8 rocm/rocm-terminal rocm-smi`

- Add CLI to Validate CDI Spec (amd.json)
> `amd-ctk cdi validate --path=/etc/cdi/amd.json`

- Add CLI Support from printing version
> If there is no git tag on the branch, we get an output as follows:
> ```
> ubuntu@above-coral:~$ amd-ctk version
> Version: 367b8d9-dirty
> Build Date: 2025-07-02T04:58:20+0000
> GitCommit: 367b8d9
> ```
> If there is a git tag on the branch and commit and local changes have been added on top of that, we get an output as follows:
> ```
> ubuntu@above-coral:~$ amd-ctk version
> Version: v1.0.0-10-ga767613-dirty
> Build Date: 2025-07-02T05:13:59+0000
> GitCommit: a767613
> ```
> If the branch is checkout out to the git tag and local uncommitted changes have been added on top of that, we get an output as follows:
> ```
> ubuntu@above-coral:~$ amd-ctk version
> Version: v1.0.0-dirty
> Build Date: 2025-07-02T05:22:03+0000
> GitCommit: ebfa6de
> ```
> If the branch is checkout out to the git tag and no changes have been added on top of that, we get an output as follows:
> ```
> ubuntu@above-coral:~$ amd-ctk version
> Version: v1.0.0
> Build Date: 2025-07-02T05:22:03+0000
> GitCommit: ebfa6de
> ```