### PR TITLE
Fix for https://github.com/ROCm/container-toolkit/issues/59

### DIFF
--- a/cmd/amd-ctk/runtime/configure/configure.go
+++ b/cmd/amd-ctk/runtime/configure/configure.go
@@ -18,7 +18,6 @@ package configure
 
 import (
 	"fmt"
-	"os/user"
 
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/runtime/engine"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/runtime/engine/docker"
@@ -90,11 +89,6 @@ func AddNewCommand() *cli.Command {
 }
 
 func validateConfigOptions(c *cli.Context, cfgOptions *configOptions) error {
-
-	curUser, err := user.Current()
-	if err != nil || curUser.Uid != "0" {
-		return fmt.Errorf("Permission denied: Not running as root")
-	}
 	if cfgOptions.runtime != "docker" {
 		return fmt.Errorf("unsupported runtime engine: %v", cfgOptions.runtime)
 	}

--- a/internal/cdi/cdi_test.go
+++ b/internal/cdi/cdi_test.go
@@ -61,7 +61,7 @@ func TestInterface(t *testing.T) {
 	err := cdi.GenerateSpec()
 	Assert(t, err == nil, fmt.Sprintf("failed to generate cdi spec, Err: %v", err))
 
-	cdi.specPath = "/tmp"
+	cdi.specPath = "/tmp/"
 	err = cdi.WriteSpec()
 	Assert(t, err == nil, fmt.Sprintf("WriteSpec() returned error %v", err))
 

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -44,10 +44,31 @@ func SetLogFile(file string) {
 
 // SetLogDir sets the path to the directory of logs
 func SetLogDir() {
+
+	isWriteable := func(path string) bool {
+		// Create a temporary file in the specified directory.
+		// os.CreateTemp will return an error if the directory is not writable.
+		file, err := os.CreateTemp(path, "tmp-test-")
+		if err != nil {
+			return false
+		}
+		file.Close()           // Close the file
+		os.Remove(file.Name()) // Clean up the temporary file
+
+		return true
+	}
+
 	if os.Getenv("LOGDIR") != "" {
 		logdir = os.Getenv("LOGDIR")
+
+		//check if the user has permission to write to this location
+		if !isWriteable(logdir) {
+			log.Fatalf("User doesn't have write permission for the specified directory: %v", logdir)
+		}
+
 		return
 	}
+
 	// Get the current user's information.
 	currentUser, err := user.Current()
 	if err != nil {


### PR DESCRIPTION
Check if the user has permission to write to the directory if LOGDIR environment variable is set.
Fixed a UT breakage, don't need to check for root user anymore.

## Motivation

<!-- Explain the purpose of this PR and the goals it aims to achieve. -->

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
