### PR TITLE
Adding Enable and Disable CLIs for GPU Tracker

### DIFF
--- a/cmd/amd-ctk/gpu-tracker/disable/disable.go
+++ b/cmd/amd-ctk/gpu-tracker/disable/disable.go
@@ -1,0 +1,65 @@
+/**
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package disable
+
+import (
+	"fmt"
+	"os/user"
+
+	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	"github.com/urfave/cli/v2"
+)
+
+func AddNewCommand() *cli.Command {
+	// Add the gpu-tracker disable command
+	gpuTrackerDisableCmd := cli.Command{
+		Name:      "disable",
+		Usage:     "Disable the GPU Tracker",
+		UsageText: "amd-ctk gpu-tracker disable [options]",
+		Before: func(c *cli.Context) error {
+			return validateGenOptions(c)
+		},
+		Action: func(c *cli.Context) error {
+			return performAction(c)
+		},
+	}
+
+	return &gpuTrackerDisableCmd
+}
+
+func validateGenOptions(c *cli.Context) error {
+	curUser, err := user.Current()
+	if err != nil || curUser.Uid != "0" {
+		return fmt.Errorf("Permission denied: Not running as root")
+	}
+
+	return nil
+}
+
+func performAction(c *cli.Context) error {
+	gpuTracker, err := gpuTracker.New()
+	if err != nil {
+		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
+	}
+
+	err = gpuTracker.Disable()
+	if err != nil {
+		return fmt.Errorf("Failed to Reset GPU Tracker, Error: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/amd-ctk/gpu-tracker/enable/enable.go
+++ b/cmd/amd-ctk/gpu-tracker/enable/enable.go
@@ -1,0 +1,65 @@
+/**
+# Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the \"License\");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an \"AS IS\" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+**/
+
+package enable
+
+import (
+	"fmt"
+	"os/user"
+
+	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	"github.com/urfave/cli/v2"
+)
+
+func AddNewCommand() *cli.Command {
+	// Add the gpu-tracker enable command
+	gpuTrackerEnableCmd := cli.Command{
+		Name:      "enable",
+		Usage:     "Enable the GPU Tracker",
+		UsageText: "amd-ctk gpu-tracker enable [options]",
+		Before: func(c *cli.Context) error {
+			return validateGenOptions(c)
+		},
+		Action: func(c *cli.Context) error {
+			return performAction(c)
+		},
+	}
+
+	return &gpuTrackerEnableCmd
+}
+
+func validateGenOptions(c *cli.Context) error {
+	curUser, err := user.Current()
+	if err != nil || curUser.Uid != "0" {
+		return fmt.Errorf("Permission denied: Not running as root")
+	}
+
+	return nil
+}
+
+func performAction(c *cli.Context) error {
+	gpuTracker, err := gpuTracker.New()
+	if err != nil {
+		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
+	}
+
+	err = gpuTracker.Enable()
+	if err != nil {
+		return fmt.Errorf("Failed to Reset GPU Tracker, Error: %v", err)
+	}
+
+	return nil
+}

--- a/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
+++ b/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"os/user"
 
+	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/disable"
+	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/enable"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/initialize"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/release"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/reset"
@@ -55,6 +57,8 @@ amd-ctk gpu-tracker [command] [options]`,
 	}
 
 	gpuTrackerCmd.Subcommands = []*cli.Command{
+		disable.AddNewCommand(),
+		enable.AddNewCommand(),
 		initialize.AddNewCommand(),
 		reset.AddNewCommand(),
 		release.AddNewCommand(),

--- a/internal/gpu-tracker/gpu-tracker_test.go
+++ b/internal/gpu-tracker/gpu-tracker_test.go
@@ -15,7 +15,7 @@ func mockIsGPUTrackerInitialized() (bool, error) {
 	return true, nil
 }
 
-func mockInitializeGPUTracker(op string) error {
+func mockInitializeGPUTracker() error {
 	return nil
 }
 
@@ -143,6 +143,7 @@ func mockParseGPUsList(gpus string) ([]int, []string, []string, error) {
 
 func mockReadGPUTrackerFile() (gpu_tracker_data_t, error) {
 	return gpu_tracker_data_t{
+		Enabled: true,
 		GPUsStatus: map[int]gpu_status_t{
 			0: {
 				UUID:          "0xef2c1799a1f3e2ed",
@@ -203,6 +204,12 @@ func TestInterface(t *testing.T) {
 
 	err := gpuTracker.Init()
 	Assert(t, err == nil, fmt.Sprintf("Init() returned error %v", err))
+
+	err = gpuTracker.Enable()
+	Assert(t, err == nil, fmt.Sprintf("Enable() returned error %v", err))
+
+	err = gpuTracker.Disable()
+	Assert(t, err == nil, fmt.Sprintf("Disable() returned error %v", err))
 
 	err = gpuTracker.ShowStatus()
 	Assert(t, err == nil, fmt.Sprintf("ShowStatus() returned error %v", err))


### PR DESCRIPTION
## Motivation

With earlier implementation, it was compulsory to reset GPU Tracker in case of any change in GPU Partition scheme even if user does not want to really use the GPU Tracker feature. This PR introduced an enable and disable CLI for GPU Tracker. GPU Tracker is disabled by default. Due to this, anyone not using GPU Tracker can totally ignore the presence of the feature and is not impacted in any way.

## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

<!-- Briefly summarize test outcomes. -->

## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
