### PR TITLE
Adding a batch script file to run all_reduce_perf(rccl-tests) in enroot

### DIFF
--- a/tests/enroot/batch_scripts/rccl_tests_sbatch.sh
+++ b/tests/enroot/batch_scripts/rccl_tests_sbatch.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+#SBATCH --nodes=2
+#SBATCH --ntasks=2
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-task=8
+#SBATCH --job-name=rccl_test
+#SBATCH --output=logs/rccl_test_%j.out
+#SBATCH --error=logs/rccl_test_%j.err
+
+set -e
+
+mkdir -p logs
+
+# Customizable container image with default value
+DOCKER_IMAGE_VERSION=${DOCKER_IMAGE_VERSION:-"ubuntu24_rocm-7.0.2_rccl-7.0.2_anp-v1.2.0_ainic-1.117.5-a-56"}
+
+CONTAINER_IMAGE="enroot_rccl-$DOCKER_IMAGE_VERSION.sqsh"
+
+echo "Pulling container image for version: $DOCKER_IMAGE_VERSION and saving to $CONTAINER_IMAGE"
+
+# Pull the image on every allocated node
+srun --ntasks-per-node=1 bash -c "
+   if [ ! -f \"$PWD/$CONTAINER_IMAGE\" ]; then
+       echo \"Node \$(hostname): Pulling container image and saving to $CONTAINER_IMAGE\"
+       if ! enroot import -o \"$PWD/$CONTAINER_IMAGE\" \"docker://rocm/roce-workload:$DOCKER_IMAGE_VERSION\"; then
+           echo \"Node \$(hostname): Failed to pull container image\" >&2
+           exit 1
+       fi
+   else
+       echo \"Node \$(hostname): Container image already exists, skipping pull\"
+   fi
+"
+# Export environment variables
+export HSA_NO_SCRATCH_RECLAIM=1
+export NCCL_SOCKET_IFNAME=ens50f0
+export NCCL_IB_DISABLE=0
+export PMIX_MCA_gds=hash
+export OMPI_MCA_btl_tcp_if_exclude=lo,docker0
+export IONIC_LOCKFREE=all
+export NCCL_GDRCOPY_ENABLE=0
+export NCCL_GDR_FLUSH_DISABLE=1
+export NCCL_GRAPH_DUMP_FILE=/tmp/graph_all.txt
+export NCCL_IB_GID_INDEX=1
+export NCCL_PXN_DISABLE=0
+export NCCL_IB_QPS_PER_CONNECTION=1
+export NCCL_IB_TC=96
+export NCCL_IB_FIFO_TC=184
+export NCCL_IGNORE_CPU_AFFINITY=1
+export NCCL_IB_USE_INLINE=1
+export NCCL_NET_OPTIONAL_RECV_COMPLETION=1
+export NCCL_TOPO_DUMP_FILE=/tmp/topo_all.txt
+export RCCL_GDR_FLUSH_GPU_MEM_NO_RELAXED_ORDERING=0
+export OMPI_MCA_btl=^openib
+
+# Run the command
+srun --mpi=pmix \
+        --container-image="$PWD/$CONTAINER_IMAGE" \
+     /root/rccl-tests/build/all_reduce_perf -b 16 -e 8G -f 2 -g 8


### PR DESCRIPTION
containers on a slurm cluster

## Motivation

Provide a sample sbatch script to run rccl-tests on enroot containers on a slurm cluster
## Technical Details

<!-- Explain the changes along with any relevant GitHub links. -->

## Test Plan

<!-- Explain any relevant testing done to verify this PR. -->

## Test Result

Node gpuf2b8: Pulling container image and saving to enroot_rccl-ubuntu24_rocm-7.0.2_rccl-7.0.2_anp-v1.2.0_ainic-1.117.5-a-56.sqsh
Node gpuf2c3: Pulling container image and saving to enroot_rccl-ubuntu24_rocm-7.0.2_rccl-7.0.2_anp-v1.2.0_ainic-1.117.5-a-56.sqsh
# Collective test starting: all_reduce_perf
# nThread 1 nGpus 8 minBytes 16 maxBytes 8589934592 step: 2(factor) warmup iters: 5 iters: 20 agg iters: 1 validation: 1 graph: 0
#
rccl-tests: Version develop:5272cd1
# Using devices
#  Rank  0 Group  0 Pid 2517106 on    gpuf2b8 device  0 [0000:05:00] AMD Instinct MI300X
#  Rank  1 Group  0 Pid 2517106 on    gpuf2b8 device  1 [0000:29:00] AMD Instinct MI300X
#  Rank  2 Group  0 Pid 2517106 on    gpuf2b8 device  2 [0000:49:00] AMD Instinct MI300X
#  Rank  3 Group  0 Pid 2517106 on    gpuf2b8 device  3 [0000:65:00] AMD Instinct MI300X
#  Rank  4 Group  0 Pid 2517106 on    gpuf2b8 device  4 [0000:85:00] AMD Instinct MI300X
#  Rank  5 Group  0 Pid 2517106 on    gpuf2b8 device  5 [0000:a9:00] AMD Instinct MI300X
#  Rank  6 Group  0 Pid 2517106 on    gpuf2b8 device  6 [0000:c9:00] AMD Instinct MI300X
#  Rank  7 Group  0 Pid 2517106 on    gpuf2b8 device  7 [0000:e5:00] AMD Instinct MI300X
#  Rank  8 Group  0 Pid 1162088 on    gpuf2c3 device  0 [0000:05:00] AMD Instinct MI300X
#  Rank  9 Group  0 Pid 1162088 on    gpuf2c3 device  1 [0000:29:00] AMD Instinct MI300X
#  Rank 10 Group  0 Pid 1162088 on    gpuf2c3 device  2 [0000:49:00] AMD Instinct MI300X
#  Rank 11 Group  0 Pid 1162088 on    gpuf2c3 device  3 [0000:65:00] AMD Instinct MI300X
#  Rank 12 Group  0 Pid 1162088 on    gpuf2c3 device  4 [0000:85:00] AMD Instinct MI300X
#  Rank 13 Group  0 Pid 1162088 on    gpuf2c3 device  5 [0000:a9:00] AMD Instinct MI300X
#  Rank 14 Group  0 Pid 1162088 on    gpuf2c3 device  6 [0000:c9:00] AMD Instinct MI300X
#  Rank 15 Group  0 Pid 1162088 on    gpuf2c3 device  7 [0000:e5:00] AMD Instinct MI300X
#
#                                                              out-of-place                       in-place
#       size         count      type   redop    root     time   algbw   busbw #wrong     time   algbw   busbw #wrong
#        (B)    (elements)                               (us)  (GB/s)  (GB/s)            (us)  (GB/s)  (GB/s)
          16             4     float     sum      -1    110.1    0.00    0.00      0    83.48    0.00    0.00      0
          32             8     float     sum      -1    785.0    0.00    0.00      0    69.51    0.00    0.00      0
          64            16     float     sum      -1    68.13    0.00    0.00      0    68.95    0.00    0.00      0
         128            32     float     sum      -1    69.32    0.00    0.00      0    86.55    0.00    0.00      0
         256            64     float     sum      -1    68.56    0.00    0.01      0    85.91    0.00    0.01      0
         512           128     float     sum      -1    49.36    0.01    0.02      0    50.14    0.01    0.02      0
        1024           256     float     sum      -1    57.35    0.02    0.03      0    52.05    0.02    0.04      0
        2048           512     float     sum      -1    177.7    0.01    0.02      0    50.48    0.04    0.08      0
        4096          1024     float     sum      -1    205.9    0.02    0.04      0    55.90    0.07    0.14      0
        8192          2048     float     sum      -1    648.2    0.01    0.02      0    652.5    0.01    0.02      0
       16384          4096     float     sum      -1   2862.6    0.01    0.01      0   4827.6    0.00    0.01      0
       32768          8192     float     sum      -1    840.8    0.04    0.07      0   2166.1    0.02    0.03      0
       65536         16384     float     sum      -1    788.3    0.08    0.16      0   1220.2    0.05    0.10      0
      131072         32768     float     sum      -1   1211.6    0.11    0.20      0   4151.5    0.03    0.06      0
      262144         65536     float     sum      -1   3683.6    0.07    0.13      0    676.9    0.39    0.73      0
      524288        131072     float     sum      -1   1789.9    0.29    0.55      0   1059.6    0.49    0.93      0
     1048576        262144     float     sum      -1   1520.3    0.69    1.29      0   5507.6    0.19    0.36      0
     2097152        524288     float     sum      -1   5755.7    0.36    0.68      0   5144.9    0.41    0.76      0
     4194304       1048576     float     sum      -1   5488.4    0.76    1.43      0   4745.4    0.88    1.66      0
     8388608       2097152     float     sum      -1   5150.2    1.63    3.05      0   4494.5    1.87    3.50      0
    16777216       4194304     float     sum      -1   5868.9    2.86    5.36      0   6543.9    2.56    4.81      0
    33554432       8388608     float     sum      -1   6273.4    5.35   10.03      0   6518.8    5.15    9.65      0
    67108864      16777216     float     sum      -1   7335.9    9.15   17.15      0   8916.3    7.53   14.11      0
   134217728      33554432     float     sum      -1    11638   11.53   21.62      0    13451    9.98   18.71      0
   268435456      67108864     float     sum      -1    13616   19.72   36.97      0    14003   19.17   35.94      0
   536870912     134217728     float     sum      -1    14770   36.35   68.15      0    12216   43.95   82.40      0
  1073741824     268435456     float     sum      -1    15907   67.50  126.57      0    18592   57.75  108.29      0
  2147483648     536870912     float     sum      -1    24777   86.67  162.51      0    27807   77.23  144.81      0
  4294967296    1073741824     float     sum      -1    47100   91.19  170.98      0    49747   86.34  161.88      0
  8589934592    2147483648     float     sum      -1    88545   97.01  181.90      0    89759   95.70  179.44      0
# Errors with asterisks indicate errors that have exceeded the maximum threshold.
# Out of bounds values : 0 OK
# Avg bus bandwidth    : 26.2907
#
# Collective test concluded: all_reduce_perf
## Submission Checklist

- [ ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
