### PR TITLE
fix: allow non root user generate and validate the cdi spec

### DIFF
--- a/cmd/amd-ctk/cdi/generate/generate.go
+++ b/cmd/amd-ctk/cdi/generate/generate.go
@@ -18,7 +18,6 @@ package generate
 
 import (
 	"fmt"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -63,11 +62,6 @@ func AddNewCommand() *cli.Command {
 }
 
 func validateGenOptions(c *cli.Context, genOptions *generateOptions) error {
-	curUser, err := user.Current()
-	if err != nil || curUser.Uid != "0" {
-		return fmt.Errorf("Permission denied: Not running as root")
-	}
-
 	out, err := filepath.Abs(genOptions.output)
 	if err != nil {
 		return fmt.Errorf("incorrect output file, Err: %v", err)

--- a/cmd/amd-ctk/cdi/validate/validate.go
+++ b/cmd/amd-ctk/cdi/validate/validate.go
@@ -18,7 +18,6 @@ package validate
 
 import (
 	"fmt"
-	"os/user"
 	"path/filepath"
 	"strings"
 
@@ -63,11 +62,6 @@ func AddNewCommand() *cli.Command {
 }
 
 func validateValOptions(c *cli.Context, valOptions *validateOptions) error {
-	curUser, err := user.Current()
-	if err != nil || curUser.Uid != "0" {
-		return fmt.Errorf("Permission denied: Not running as root")
-	}
-
 	out, err := filepath.Abs(valOptions.cdiSpecPath)
 	if err != nil {
 		return fmt.Errorf("Incorrect CDI spec file, Error: %v", err)


### PR DESCRIPTION
## Motivation

This allows a non root user to generate a cdi spec. If the user does not have rights to write to the output location, they will get a permission denied error, otherwise the command should work fine and the user should should get the spec.

## Technical Details
We just remove the _are you root_ check for the command.

## Test Plan

Tested on a machine with GPUs to see if a non root user is successfully able to create a cdi spec which lists the gpus on the machine.

## Test Result

The user was successfully able to generate the file

## Submission Checklist

- [X] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
