### PR TITLE
chore: add ci workflow to build and unit test on PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,84 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.0'
+    
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    
+    - name: Build container-toolkit
+      run: make container-toolkit
+    
+    - name: Build container-toolkit-ctk
+      run: make container-toolkit-ctk
+    
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: binaries
+        path: |
+          bin/deb/amd-container-runtime
+          bin/deb/amd-ctk
+        retention-days: 7
+
+  test:
+    runs-on: ubuntu-24.04
+    needs: build
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22.0'
+    
+    - name: Cache Go modules
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/go/pkg/mod
+          ~/.cache/go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: binaries
+        path: bin/deb/
+    
+    - name: Make binaries executable
+      run: chmod +x bin/deb/amd-ctk bin/deb/amd-container-runtime
+    
+    - name: Run tests
+      run: make test


### PR DESCRIPTION
## Motivation

This pull request introduces a new GitHub Actions workflow for running build and test make targets.

## Technical Details

Added a `.github/workflows/ci.yml` file that defines a CI pipeline triggered on pushes and pull requests to `main`.
## Test Plan

NA

## Test Result

NA

## Submission Checklist

- [X ] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
