### PR TITLE
Move user-facing output from libraries to CLI callers

### DIFF
--- a/cmd/amd-ctk/cdi/generate/generate.go
+++ b/cmd/amd-ctk/cdi/generate/generate.go
@@ -87,5 +87,6 @@ func performAction(c *cli.Context, genOptions *generateOptions) error {
 		return fmt.Errorf("Failed to write generated runtime CDI spec, Error: %v", err)
 	}
 
+	fmt.Printf("Generated CDI spec: %v\n", genOptions.output)
 	return nil
 }

--- a/cmd/amd-ctk/cdi/validate/validate.go
+++ b/cmd/amd-ctk/cdi/validate/validate.go
@@ -76,12 +76,15 @@ func performAction(c *cli.Context, valOptions *validateOptions) error {
 	}
 
 	// Validate CDI spec
+	fmt.Printf("Validating CDI spec: %v\n", valOptions.cdiSpecPath)
 	result, err := cdi.ValidateSpec()
 	if err != nil {
-		return fmt.Errorf("Failed to validate CDI spec")
+		return fmt.Errorf("validating CDI spec: %w", err)
 	}
-	if result == true {
-		fmt.Printf("CDI spec is valid\n")
+	if result {
+		fmt.Println("CDI spec is valid")
+	} else {
+		fmt.Println("CDI spec is invalid\nPlease regenerate CDI spec")
 	}
 
 	return nil

--- a/cmd/amd-ctk/gpu-tracker/disable/disable.go
+++ b/cmd/amd-ctk/gpu-tracker/disable/disable.go
@@ -56,10 +56,20 @@ func performAction(c *cli.Context) error {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
-	err = gpuTracker.Disable()
+	enabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("Failed to Reset GPU Tracker, Error: %v", err)
+		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
+	}
+	if !enabled {
+		fmt.Println("GPU Tracker is already disabled")
+		return nil
 	}
 
+	err = gpuTracker.Disable()
+	if err != nil {
+		return fmt.Errorf("Failed to disable GPU Tracker, Error: %v", err)
+	}
+
+	fmt.Println("GPU Tracker has been disabled")
 	return nil
 }

--- a/cmd/amd-ctk/gpu-tracker/enable/enable.go
+++ b/cmd/amd-ctk/gpu-tracker/enable/enable.go
@@ -56,10 +56,20 @@ func performAction(c *cli.Context) error {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
-	err = gpuTracker.Enable()
+	enabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("Failed to Reset GPU Tracker, Error: %v", err)
+		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
+	}
+	if enabled {
+		fmt.Println("GPU Tracker is already enabled")
+		return nil
 	}
 
+	err = gpuTracker.Enable()
+	if err != nil {
+		return fmt.Errorf("Failed to enable GPU Tracker, Error: %v", err)
+	}
+
+	fmt.Println("GPU Tracker has been enabled")
 	return nil
 }

--- a/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
+++ b/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
@@ -94,6 +94,15 @@ func performAction(c *cli.Context) error {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
+	enabled, err := gpuTracker.IsEnabled()
+	if err != nil {
+		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
+	}
+	if !enabled {
+		fmt.Println("GPU Tracker is disabled")
+		return nil
+	}
+
 	switch operation {
 	case "exclusive":
 		gpuTracker.MakeGPUsExclusive(gpuIDs)

--- a/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
+++ b/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/release"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/reset"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker/status"
-	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	gpuTrackerLib "github.com/ROCm/container-toolkit/internal/gpu-tracker"
 	"github.com/urfave/cli/v2"
 )
 
@@ -89,7 +89,7 @@ func performAction(c *cli.Context) error {
 	gpuIDs := c.Args().Get(0)
 	operation := c.Args().Get(1)
 
-	gpuTracker, err := gpuTracker.New()
+	gpuTracker, err := gpuTrackerLib.New()
 	if err != nil {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
@@ -103,13 +103,36 @@ func performAction(c *cli.Context) error {
 		return nil
 	}
 
+	var res *gpuTrackerLib.AccessibilityResult
 	switch operation {
 	case "exclusive":
-		gpuTracker.MakeGPUsExclusive(gpuIDs)
+		res, err = gpuTracker.MakeGPUsExclusive(gpuIDs)
+		if err != nil {
+			return fmt.Errorf("making GPUs %s exclusive: %v", gpuIDs, err)
+		}
+		if len(res.Changed) > 0 {
+			fmt.Printf("GPUs %v have been made exclusive\n", res.Changed)
+		}
+		if len(res.NotChanged) > 0 {
+			fmt.Printf("GPUs %v have not been made exclusive because more than one container is currently using it\n", res.NotChanged)
+		}
 	case "shared":
-		gpuTracker.MakeGPUsShared(gpuIDs)
+		res, err = gpuTracker.MakeGPUsShared(gpuIDs)
+		if err != nil {
+			return fmt.Errorf("making GPUs %s shared: %v", gpuIDs, err)
+		}
+		if len(res.Changed) > 0 {
+			fmt.Printf("GPUs %v have been made shared\n", res.Changed)
+		}
 	default:
 		return cli.Exit("Error: Invalid operation. Must be 'exclusive' or 'shared'", 1)
+	}
+
+	if len(res.InvalidRanges) > 0 {
+		fmt.Printf("Ignoring %v GPUs Ranges as they are invalid\n", res.InvalidRanges)
+	}
+	if len(res.InvalidGPUs) > 0 {
+		fmt.Printf("Ignoring %v GPUs as they are invalid\n", res.InvalidGPUs)
 	}
 
 	return nil

--- a/cmd/amd-ctk/gpu-tracker/reset/reset.go
+++ b/cmd/amd-ctk/gpu-tracker/reset/reset.go
@@ -56,10 +56,19 @@ func performAction(c *cli.Context) error {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
+	wasEnabled, err := gpuTracker.IsEnabled()
+	if err != nil {
+		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
+	}
+
 	err = gpuTracker.Reset()
 	if err != nil {
 		return fmt.Errorf("Failed to Reset GPU Tracker, Error: %v", err)
 	}
 
+	fmt.Println("GPU Tracker has been reset")
+	if wasEnabled {
+		fmt.Println("Since GPU Tracker was enabled, it is recommended to stop and restart running containers to get the most accurate GPU Tracker status")
+	}
 	return nil
 }

--- a/cmd/amd-ctk/gpu-tracker/status/status.go
+++ b/cmd/amd-ctk/gpu-tracker/status/status.go
@@ -19,8 +19,9 @@ package status
 import (
 	"fmt"
 	"os/user"
+	"strings"
 
-	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	gpuTracker "github.com/ROCm/container-toolkit/internal/gpu-tracker"
 	"github.com/urfave/cli/v2"
 )
 
@@ -51,12 +52,12 @@ func validateGenOptions(c *cli.Context) error {
 }
 
 func performAction(c *cli.Context) error {
-	gpuTracker, err := gpuTracker.New()
+	tracker, err := gpuTracker.New()
 	if err != nil {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
-	enabled, err := gpuTracker.IsEnabled()
+	enabled, err := tracker.IsEnabled()
 	if err != nil {
 		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
 	}
@@ -65,9 +66,26 @@ func performAction(c *cli.Context) error {
 		return nil
 	}
 
-	err = gpuTracker.ShowStatus()
+	entries, err := tracker.ShowStatus()
 	if err != nil {
 		return fmt.Errorf("Failed to show GPUs status, Error: %v", err)
+	}
+
+	fmt.Println(strings.Repeat("-", 120))
+	fmt.Printf("%-10s%-25s%-20s%-65s\n", "GPU Id", "UUID", "Accessibility", "Container Ids")
+	fmt.Println(strings.Repeat("-", 120))
+	for _, entry := range entries {
+		if len(entry.ContainerIds) > 0 {
+			for idx, id := range entry.ContainerIds {
+				if idx == 0 {
+					fmt.Printf("%-10v%-25v%-20v%-65v\n", entry.GPUId, entry.UUID, entry.Accessibility, id)
+				} else {
+					fmt.Printf("%-10v%-25v%-20v%-65v\n", "", "", "", id)
+				}
+			}
+		} else {
+			fmt.Printf("%-10v%-25v%-20v%-65v\n", entry.GPUId, entry.UUID, entry.Accessibility, "-")
+		}
 	}
 
 	return nil

--- a/cmd/amd-ctk/gpu-tracker/status/status.go
+++ b/cmd/amd-ctk/gpu-tracker/status/status.go
@@ -56,6 +56,15 @@ func performAction(c *cli.Context) error {
 		return fmt.Errorf("Failed to create GPU tracker, Error: %v", err)
 	}
 
+	enabled, err := gpuTracker.IsEnabled()
+	if err != nil {
+		return fmt.Errorf("Failed to check GPU Tracker status, Error: %v", err)
+	}
+	if !enabled {
+		fmt.Println("GPU Tracker is disabled")
+		return nil
+	}
+
 	err = gpuTracker.ShowStatus()
 	if err != nil {
 		return fmt.Errorf("Failed to show GPUs status, Error: %v", err)

--- a/internal/cdi/cdi.go
+++ b/internal/cdi/cdi.go
@@ -52,8 +52,8 @@ type Interface interface {
 	// WriteSpec writes the generated spec to disk
 	WriteSpec() error
 
-	// PrintSpec prints the generated CDI spec on the console
-	PrintSpec() error
+	// FormatSpec returns the generated CDI spec as a formatted JSON string
+	FormatSpec() (string, error)
 
 	// ValidateSpec validated the existing CDI spec on the disk
 	ValidateSpec() (bool, error)
@@ -187,51 +187,33 @@ func (cdi *cdi_t) WriteSpec() error {
 	encoder := json.NewEncoder(file)
 	encoder.SetIndent("", "  ")
 	if err := encoder.Encode(cdi.spec); err != nil {
-		fmt.Printf("Error encoding JSON: %s\n", err)
-		return err
+		return fmt.Errorf("encoding CDI spec to %s: %w", cdi.specPath, err)
 	}
 
-	logger.Log.Printf("Wrote spec to %v", cdi.specPath)
-	fmt.Printf("Generated CDI spec: %v\n", cdi.specPath)
 	return nil
 }
 
-func (cdi *cdi_t) PrintSpec() error {
+func (cdi *cdi_t) FormatSpec() (string, error) {
 	prettyJSON, err := json.MarshalIndent(cdi.spec, "", "  ")
 	if err != nil {
-		logger.Log.Printf("Failed to marshal JSON, Error: %v", err)
-		return err
+		return "", fmt.Errorf("marshaling CDI spec to JSON: %v", err)
 	}
 
-	fmt.Printf(string(prettyJSON))
-	fmt.Printf("\n")
-
-	return nil
+	return string(prettyJSON), nil
 }
 
 func (cdi *cdi_t) ValidateSpec() (bool, error) {
-	fmt.Printf("Validating CDI spec: %v\n", cdi.specPath)
-
 	savedCDISpec, err := readSpecFromFile(cdi.specPath)
 	if err != nil {
-		fmt.Printf("Failed to parse %v, Err: %v\n", cdi.specPath, err)
 		return false, err
 	}
 
 	err = cdi.GenerateSpec()
 	if err != nil {
-		fmt.Printf("Failed to generate current CDI spec, Err: %v", err)
 		return false, err
 	}
 
-	equal := reflect.DeepEqual(*savedCDISpec, cdi.spec)
-	if equal != true {
-		logger.Log.Printf("CDI spec: %v is invalid. Please regenerate CDI spec", cdi.specPath)
-		fmt.Printf("CDI spec is invalid\nPlease regenerate CDI spec\n")
-		return false, nil
-	}
-
-	return true, nil
+	return reflect.DeepEqual(*savedCDISpec, cdi.spec), nil
 }
 
 func New(sp string) (Interface, error) {

--- a/internal/cdi/cdi_test.go
+++ b/internal/cdi/cdi_test.go
@@ -77,7 +77,8 @@ func TestInterface(t *testing.T) {
 	_, err = cdi.ValidateSpec()
 	Assert(t, err == nil, fmt.Sprintf("ValidateSpec() returned error %v", err))
 
-	cdi.PrintSpec()
+	_, err = cdi.FormatSpec()
+	Assert(t, err == nil, fmt.Sprintf("FormatSpec() returned error %v", err))
 }
 
 // dummySpec is a minimal spec used by WriteSpec tests.

--- a/internal/gpu-tracker/gpu-tracker.go
+++ b/internal/gpu-tracker/gpu-tracker.go
@@ -45,6 +45,9 @@ type Interface interface {
 	// Initialize GPU Tracker
 	Init() error
 
+	// Check if GPU Tracker is enabled
+	IsEnabled() (bool, error)
+
 	// Enable GPU Tracker
 	Enable() error
 
@@ -377,12 +380,27 @@ func validateGPUsInfo(savedGPUsInfo map[int]amdgpu.DeviceInfo) (bool, error) {
 
 	equal := reflect.DeepEqual(savedGPUsInfo, currentGPUsInfo)
 	if equal != true {
-		logger.Log.Printf("GPUs info is invalid. Please reset GPU Tracker.")
-		fmt.Printf("GPUs info is invalid. Please reset GPU Tracker.\n")
 		return false, nil
 	}
 
 	return true, nil
+}
+
+func (gpuTracker *gpu_tracker_t) IsEnabled() (bool, error) {
+	initialized, err := gpuTracker.isGPUTrackerInitialized()
+	if err != nil {
+		return false, fmt.Errorf("check if GPU tracker initialized: %w", err)
+	}
+	if !initialized {
+		return false, nil
+	}
+
+	gpuTrackerData, err := gpuTracker.readGPUTrackerFile()
+	if err != nil {
+		return false, fmt.Errorf("read GPU tracker file: %w", err)
+	}
+
+	return gpuTrackerData.Enabled, nil
 }
 
 func (gpuTracker *gpu_tracker_t) Init() error {
@@ -431,8 +449,6 @@ func (gpuTracker *gpu_tracker_t) Enable() error {
 	}
 
 	if gpusTrackerData.Enabled {
-		logger.Log.Printf("GPU Tracker is already enabled")
-		fmt.Printf("GPU Tracker is already enabled\n")
 		return nil
 	}
 
@@ -459,8 +475,6 @@ func (gpuTracker *gpu_tracker_t) Enable() error {
 		return err
 	}
 
-	logger.Log.Printf("GPU Tracker has been enabled")
-	fmt.Printf("GPU Tracker has been enabled\n")
 	return nil
 }
 
@@ -503,8 +517,6 @@ func (gpuTracker *gpu_tracker_t) Disable() error {
 		}
 	}
 
-	logger.Log.Printf("GPU Tracker has been disabled")
-	fmt.Printf("GPU Tracker has been disabled\n")
 	return nil
 }
 
@@ -566,11 +578,6 @@ func (gpuTracker *gpu_tracker_t) Reset() error {
 		}
 	}
 
-	logger.Log.Printf("GPU Tracker has been reset")
-	fmt.Printf("GPU Tracker has been reset\n")
-	if gpuTrackerEnabled {
-		fmt.Printf("Since GPU Tracker was enabled, it is recommended to stop and restart running containers to get the most accurate GPU Tracker status\n")
-	}
 	return nil
 }
 
@@ -600,12 +607,6 @@ func (gpuTracker *gpu_tracker_t) ShowStatus() error {
 		logger.Log.Printf("Failed to show GPU Tracker status, Error: %v", err)
 		fmt.Printf("Failed to show GPU Tracker status, Error: %v\n", err)
 		return err
-	}
-
-	if gpusTrackerData.Enabled == false {
-		logger.Log.Printf("GPU Tracker is disabled")
-		fmt.Printf("GPU Tracker is disabled\n")
-		return nil
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
@@ -670,12 +671,6 @@ func (gpuTracker *gpu_tracker_t) MakeGPUsExclusive(gpus string) error {
 		logger.Log.Printf("Failed to make GPUs %v exclusive, Error: %v", gpus, err)
 		fmt.Printf("Failed to make GPUs %v exclusive, Error: %v\n", gpus, err)
 		return err
-	}
-
-	if gpusTrackerData.Enabled == false {
-		logger.Log.Printf("GPU Tracker is disabled")
-		fmt.Printf("GPU Tracker is disabled\n")
-		return nil
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
@@ -760,12 +755,6 @@ func (gpuTracker *gpu_tracker_t) MakeGPUsShared(gpus string) error {
 		logger.Log.Printf("Failed to make GPUs %v shared, Error: %v", gpus, err)
 		fmt.Printf("Failed to make GPUs %v shared, Error: %v\n", gpus, err)
 		return err
-	}
-
-	if gpusTrackerData.Enabled == false {
-		logger.Log.Printf("GPU Tracker is disabled")
-		fmt.Printf("GPU Tracker is disabled\n")
-		return nil
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)

--- a/internal/gpu-tracker/gpu-tracker.go
+++ b/internal/gpu-tracker/gpu-tracker.go
@@ -33,12 +33,49 @@ import (
 	"github.com/gofrs/flock"
 )
 
+// Accessibility represents the access mode of a GPU
+type Accessibility string
+
+const (
+	SHARED_ACCESS    Accessibility = "Shared"
+	EXCLUSIVE_ACCESS Accessibility = "Exclusive"
+)
+
+// accessibility is the internal int representation used for JSON serialization
+// of the tracker file, kept for backward compatibility with existing tracker files.
 type accessibility int
 
 const (
-	SHARED_ACCESS accessibility = iota
-	EXCLUSIVE_ACCESS
+	sharedAccessInt accessibility = iota
+	exclusiveAccessInt
 )
+
+func (a accessibility) toAccessibility() (Accessibility, error) {
+	switch a {
+	case sharedAccessInt:
+		return SHARED_ACCESS, nil
+	case exclusiveAccessInt:
+		return EXCLUSIVE_ACCESS, nil
+	default:
+		return "", fmt.Errorf("invalid accessibility value: %d", int(a))
+	}
+}
+
+// GPUStatusEntry represents the status of a single GPU
+type GPUStatusEntry struct {
+	GPUId         int
+	UUID          string
+	Accessibility Accessibility
+	ContainerIds  []string
+}
+
+// AccessibilityResult contains the outcome of a MakeGPUsExclusive or MakeGPUsShared operation
+type AccessibilityResult struct {
+	Changed       []int
+	NotChanged    []int
+	InvalidGPUs   []string
+	InvalidRanges []string
+}
 
 // Interface for GPU Tracker package
 type Interface interface {
@@ -58,15 +95,15 @@ type Interface interface {
 	Reset() error
 
 	// Show GPUs Status
-	ShowStatus() error
+	ShowStatus() ([]GPUStatusEntry, error)
 
 	// Make specified GPUs exclusive such that they can be used
 	// by at most one container at any instance
-	MakeGPUsExclusive(gpus string) error
+	MakeGPUsExclusive(gpus string) (*AccessibilityResult, error)
 
 	// Make specified GPUs shared such that they can be used
 	// by any number of containers at any instance
-	MakeGPUsShared(gpus string) error
+	MakeGPUsShared(gpus string) (*AccessibilityResult, error)
 
 	// Reserve GPUs for a container
 	ReserveGPUs(gpus string, containerId string) ([]int, error)
@@ -82,7 +119,7 @@ type gpu_status_t struct {
 	// Partition Type of the GPU
 	PartitionType string `json:"partitionType"`
 
-	// GPU accessibility
+	// GPU accessibility (int for backward-compatible JSON serialization)
 	Accessibility accessibility `json:"accessibility"`
 
 	// Container Ids of the containers to which the GPU is assigned
@@ -359,7 +396,7 @@ func initializeGPUTracker() error {
 		gpuTrackerData.GPUsStatus[gpuId] = gpu_status_t{
 			UUID:          gpuIdToUUIDMap[gpuId],
 			PartitionType: gpusInfo[gpuId].PartitionType,
-			Accessibility: SHARED_ACCESS,
+			Accessibility: sharedAccessInt,
 			ContainerIds:  []string{},
 		}
 	}
@@ -378,9 +415,8 @@ func validateGPUsInfo(savedGPUsInfo map[int]amdgpu.DeviceInfo) (bool, error) {
 		currentGPUsInfo[gpuId] = gpuInfo
 	}
 
-	equal := reflect.DeepEqual(savedGPUsInfo, currentGPUsInfo)
-	if equal != true {
-		return false, nil
+	if !reflect.DeepEqual(savedGPUsInfo, currentGPUsInfo) {
+		return false, fmt.Errorf("GPU info mismatch: please reset GPU Tracker")
 	}
 
 	return true, nil
@@ -429,22 +465,17 @@ func (gpuTracker *gpu_tracker_t) Enable() error {
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
 		return err
 	}
 
 	if !gpuTrackerInitialized {
-		err := gpuTracker.initializeGPUTracker()
-		if err != nil {
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
 			return err
 		}
 	}
 
 	gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to show GPU Tracker status, Error: %v", err)
-		fmt.Printf("Failed to show GPU Tracker status, Error: %v\n", err)
 		return err
 	}
 
@@ -452,30 +483,18 @@ func (gpuTracker *gpu_tracker_t) Enable() error {
 		return nil
 	}
 
-	err = gpuTracker.initializeGPUTracker()
-	if err != nil {
-		logger.Log.Printf("Failed to enable GPU Tracker, Error: %v", err)
-		fmt.Printf("Failed to enable GPU Tracker, Error: %v\n", err)
+	if err := gpuTracker.initializeGPUTracker(); err != nil {
 		return err
 	}
 
 	gpusTrackerData, err = gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to enable GPU Tracker, Error: %v", err)
-		fmt.Printf("Failed to enable GPU Tracker, Error: %v\n", err)
 		return err
 	}
 
 	gpusTrackerData.Enabled = true
 
-	err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-	if err != nil {
-		logger.Log.Printf("Failed to enable GPU Tracker, Error: %v", err)
-		fmt.Printf("Failed to enable GPU Tracker, Error: %v\n", err)
-		return err
-	}
-
-	return nil
+	return gpuTracker.writeGPUTrackerFile(gpusTrackerData)
 }
 
 func (gpuTracker *gpu_tracker_t) Disable() error {
@@ -487,32 +506,22 @@ func (gpuTracker *gpu_tracker_t) Disable() error {
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
 		return err
 	}
 
 	if !gpuTrackerInitialized {
-		err := gpuTracker.initializeGPUTracker()
-		if err != nil {
-			logger.Log.Printf("Failed to disable GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to disable GPU Tracker, Error: %v\n", err)
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
 			return err
 		}
 	} else {
 		gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 		if err != nil {
-			logger.Log.Printf("Failed to disable GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to disable GPU Tracker, Error: %v\n", err)
 			return err
 		}
 
 		gpusTrackerData.Enabled = false
 
-		err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-		if err != nil {
-			logger.Log.Printf("Failed to disable GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to disable GPU Tracker, Error: %v\n", err)
+		if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
 			return err
 		}
 	}
@@ -529,50 +538,35 @@ func (gpuTracker *gpu_tracker_t) Reset() error {
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
 		return err
 	}
 
 	gpuTrackerEnabled := false
 
 	if !gpuTrackerInitialized {
-		err := gpuTracker.initializeGPUTracker()
-		if err != nil {
-			logger.Log.Printf("Failed to reset GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to reset GPU Tracker, Error: %v\n", err)
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
 			return err
 		}
 	} else {
 		gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 		if err != nil {
-			logger.Log.Printf("Failed to reset GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to reset GPU Tracker, Error: %v\n", err)
 			return err
 		}
 
 		gpuTrackerEnabled = gpusTrackerData.Enabled
 
-		err = gpuTracker.initializeGPUTracker()
-		if err != nil {
-			logger.Log.Printf("Failed to reset GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to reset GPU Tracker, Error: %v\n", err)
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
 			return err
 		}
 
 		gpusTrackerData, err = gpuTracker.readGPUTrackerFile()
 		if err != nil {
-			logger.Log.Printf("Failed to reset GPU Tracker, Error: %v", err)
-			fmt.Printf("Failed to reset GPU Tracker, Error: %v\n", err)
 			return err
 		}
 
-		if gpuTrackerEnabled == true {
+		if gpuTrackerEnabled {
 			gpusTrackerData.Enabled = true
-			err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-			if err != nil {
-				logger.Log.Printf("Failed to reset GPU Tracker, Error: %v", err)
-				fmt.Printf("Failed to reset GPU Tracker, Error: %v\n", err)
+			if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
 				return err
 			}
 		}
@@ -581,224 +575,161 @@ func (gpuTracker *gpu_tracker_t) Reset() error {
 	return nil
 }
 
-func (gpuTracker *gpu_tracker_t) ShowStatus() error {
+func (gpuTracker *gpu_tracker_t) ShowStatus() ([]GPUStatusEntry, error) {
 	lock, err := acquireLock(gpuTracker.gpuTrackerLockFile, defaultLockTimeout)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer lock.Unlock()
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
-		return err
+		return nil, err
 	}
 
 	if !gpuTrackerInitialized {
-		err := gpuTracker.initializeGPUTracker()
-		if err != nil {
-			return err
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
+			return nil, err
 		}
 	}
 
 	gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to show GPU Tracker status, Error: %v", err)
-		fmt.Printf("Failed to show GPU Tracker status, Error: %v\n", err)
-		return err
+		return nil, err
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
 	if err != nil || result != true {
-		return err
+		return nil, err
 	}
 
-	fmt.Println(strings.Repeat("-", 120))
-	fmt.Printf("%-10s%-25s%-20s%-65s\n", "GPU Id", "UUID", "Accessibility", "Container Ids")
-	fmt.Println(strings.Repeat("-", 120))
+	var entries []GPUStatusEntry
 	for gpuId := 0; gpuId < len(gpusTrackerData.GPUsStatus); gpuId++ {
-		var accessibility string
-		switch gpusTrackerData.GPUsStatus[gpuId].Accessibility {
-		case SHARED_ACCESS:
-			accessibility = "Shared"
-		case EXCLUSIVE_ACCESS:
-			accessibility = "Exclusive"
-		default:
-			fmt.Printf("Invalid accessibility value %v\n", gpusTrackerData.GPUsStatus[gpuId].Accessibility)
-			break
+		acc, err := gpusTrackerData.GPUsStatus[gpuId].Accessibility.toAccessibility()
+		if err != nil {
+			return nil, fmt.Errorf("GPU %d: %w", gpuId, err)
 		}
-
-		if len(gpusTrackerData.GPUsStatus[gpuId].ContainerIds) > 0 {
-			for idx, id := range gpusTrackerData.GPUsStatus[gpuId].ContainerIds {
-				if idx == 0 {
-					fmt.Printf("%-10v%-25v%-20v%-65v\n", gpuId, gpusTrackerData.GPUsStatus[gpuId].UUID, accessibility, id)
-				} else {
-					fmt.Printf("%-10v%-25v%-20v%-65v\n", "", "", "", id)
-				}
-			}
-		} else {
-			fmt.Printf("%-10v%-25v%-20v%-65v\n", gpuId, gpusTrackerData.GPUsStatus[gpuId].UUID, accessibility, "-")
-		}
+		entries = append(entries, GPUStatusEntry{
+			GPUId:         gpuId,
+			UUID:          gpusTrackerData.GPUsStatus[gpuId].UUID,
+			Accessibility: acc,
+			ContainerIds:  gpusTrackerData.GPUsStatus[gpuId].ContainerIds,
+		})
 	}
 
-	return nil
+	return entries, nil
 }
 
-func (gpuTracker *gpu_tracker_t) MakeGPUsExclusive(gpus string) error {
+func (gpuTracker *gpu_tracker_t) MakeGPUsExclusive(gpus string) (*AccessibilityResult, error) {
 	lock, err := acquireLock(gpuTracker.gpuTrackerLockFile, defaultLockTimeout)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer lock.Unlock()
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
-		return err
+		return nil, err
 	}
 
 	if !gpuTrackerInitialized {
-		err = gpuTracker.initializeGPUTracker()
-		if err != nil {
-			return err
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
+			return nil, err
 		}
 	}
 
 	gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to make GPUs %v exclusive, Error: %v", gpus, err)
-		fmt.Printf("Failed to make GPUs %v exclusive, Error: %v\n", gpus, err)
-		return err
+		return nil, err
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
 	if err != nil || result != true {
-		return err
+		return nil, err
 	}
 
 	validGPUs, invalidGPUs, invalidGPUsRange, err := gpuTracker.parseGPUsList(gpus)
 	if err != nil {
-		logger.Log.Printf("Failed to parse GPUs list %v, Error: %v", gpus, err)
-		fmt.Printf("Failed to parse GPUs list %v, Error: %v\n", gpus, err)
-		return err
+		return nil, err
 	}
 
-	gpusMadeExclusive := []int{}
-	gpusNotMadeExclusive := []int{}
+	res := &AccessibilityResult{
+		InvalidGPUs:   invalidGPUs,
+		InvalidRanges: invalidGPUsRange,
+	}
 
 	for _, gpuId := range validGPUs {
 		if len(gpusTrackerData.GPUsStatus[gpuId].ContainerIds) < 2 {
 			gpusTrackerData.GPUsStatus[gpuId] = gpu_status_t{
 				UUID:          gpusTrackerData.GPUsStatus[gpuId].UUID,
 				PartitionType: gpusTrackerData.GPUsStatus[gpuId].PartitionType,
-				Accessibility: EXCLUSIVE_ACCESS,
+				Accessibility: exclusiveAccessInt,
 				ContainerIds:  gpusTrackerData.GPUsStatus[gpuId].ContainerIds,
 			}
-			gpusMadeExclusive = append(gpusMadeExclusive, gpuId)
+			res.Changed = append(res.Changed, gpuId)
 		} else {
-			gpusNotMadeExclusive = append(gpusNotMadeExclusive, gpuId)
+			res.NotChanged = append(res.NotChanged, gpuId)
 		}
 	}
 
-	err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-	if err != nil {
-		logger.Log.Printf("Failed to make GPUs exclusive, Error: %v", err)
-		fmt.Printf("Failed to make GPUs exclusive, Error: %v\n", err)
-		return err
+	if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
+		return nil, err
 	}
 
-	if len(gpusMadeExclusive) > 0 {
-		logger.Log.Printf("GPUs %v have been made exclusive", gpusMadeExclusive)
-		fmt.Printf("GPUs %v have been made exclusive\n", gpusMadeExclusive)
-	}
-	if len(gpusNotMadeExclusive) > 0 {
-		logger.Log.Printf("GPUs %v have not been made exclusive because more than one container is currently using it", gpusNotMadeExclusive)
-		fmt.Printf("GPUs %v have not been made exclusive because more than one container is currently using it\n", gpusNotMadeExclusive)
-	}
-	if len(invalidGPUsRange) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs Ranges as they are invalid", invalidGPUsRange)
-		fmt.Printf("Ignoring %v GPUs Ranges as they are invalid\n", invalidGPUsRange)
-	}
-	if len(invalidGPUs) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs as they are invalid", invalidGPUs)
-		fmt.Printf("Ignoring %v GPUs as they are invalid\n", invalidGPUs)
-	}
-
-	return nil
+	return res, nil
 }
 
-func (gpuTracker *gpu_tracker_t) MakeGPUsShared(gpus string) error {
+func (gpuTracker *gpu_tracker_t) MakeGPUsShared(gpus string) (*AccessibilityResult, error) {
 	lock, err := acquireLock(gpuTracker.gpuTrackerLockFile, defaultLockTimeout)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer lock.Unlock()
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
-		return err
+		return nil, err
 	}
 
 	if !gpuTrackerInitialized {
-		err = gpuTracker.initializeGPUTracker()
-		if err != nil {
-			return err
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
+			return nil, err
 		}
 	}
 
 	gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to make GPUs %v shared, Error: %v", gpus, err)
-		fmt.Printf("Failed to make GPUs %v shared, Error: %v\n", gpus, err)
-		return err
+		return nil, err
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
 	if err != nil || result != true {
-		return err
+		return nil, err
 	}
 
 	validGPUs, invalidGPUs, invalidGPUsRange, err := gpuTracker.parseGPUsList(gpus)
 	if err != nil {
-		logger.Log.Printf("Failed to parse GPUs list %v, Error: %v", gpus, err)
-		fmt.Printf("Failed to parse GPUs list %v, Error: %v\n", gpus, err)
-		return err
+		return nil, err
 	}
 
 	for _, gpuId := range validGPUs {
 		gpusTrackerData.GPUsStatus[gpuId] = gpu_status_t{
 			UUID:          gpusTrackerData.GPUsStatus[gpuId].UUID,
 			PartitionType: gpusTrackerData.GPUsStatus[gpuId].PartitionType,
-			Accessibility: SHARED_ACCESS,
+			Accessibility: sharedAccessInt,
 			ContainerIds:  gpusTrackerData.GPUsStatus[gpuId].ContainerIds,
 		}
 	}
 
-	err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-	if err != nil {
-		logger.Log.Printf("Failed to make GPUs shared, Error: %v", err)
-		fmt.Printf("Failed to make GPUs shared, Error: %v\n", err)
-		return err
+	if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
+		return nil, err
 	}
 
-	if len(validGPUs) > 0 {
-		logger.Log.Printf("GPUs %v have been made shared", validGPUs)
-		fmt.Printf("GPUs %v have been made shared\n", validGPUs)
-	}
-	if len(invalidGPUsRange) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs Ranges as they are invalid", invalidGPUsRange)
-		fmt.Printf("Ignoring %v GPUs Ranges as they are invalid\n", invalidGPUsRange)
-	}
-	if len(invalidGPUs) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs as they are invalid", invalidGPUs)
-		fmt.Printf("Ignoring %v GPUs as they are invalid\n", invalidGPUs)
-	}
-
-	return nil
+	return &AccessibilityResult{
+		Changed:       validGPUs,
+		InvalidGPUs:   invalidGPUs,
+		InvalidRanges: invalidGPUsRange,
+	}, nil
 }
 
 func (gpuTracker *gpu_tracker_t) ReserveGPUs(gpus string, containerId string) ([]int, error) {
@@ -810,55 +741,46 @@ func (gpuTracker *gpu_tracker_t) ReserveGPUs(gpus string, containerId string) ([
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
 		return []int{}, err
 	}
 
 	if !gpuTrackerInitialized {
-		err = gpuTracker.initializeGPUTracker()
-		if err != nil {
+		if err := gpuTracker.initializeGPUTracker(); err != nil {
 			return []int{}, err
 		}
 	}
 
 	gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 	if err != nil {
-		logger.Log.Printf("Failed to reserve GPUs %v, Error: %v", gpus, err)
-		fmt.Printf("Failed to reserve GPUs %v, Error: %v\n", gpus, err)
 		return []int{}, err
 	}
 
 	validGPUs, invalidGPUs, invalidGPUsRange, err := gpuTracker.parseGPUsList(gpus)
 	if err != nil {
-		logger.Log.Printf("Failed to parse GPUs list %v, Error: %v", gpus, err)
-		fmt.Printf("Failed to parse GPUs list %v, Error: %v\n", gpus, err)
 		return []int{}, err
 	}
 	if len(invalidGPUsRange) > 0 {
 		logger.Log.Printf("Ignoring %v GPUs Ranges as they are invalid", invalidGPUsRange)
-		fmt.Printf("Ignoring %v GPUs Ranges as they are invalid\n", invalidGPUsRange)
 	}
 	if len(invalidGPUs) > 0 {
 		logger.Log.Printf("Ignoring %v GPUs as they are invalid", invalidGPUs)
-		fmt.Printf("Ignoring %v GPUs as they are invalid\n", invalidGPUs)
 	}
 
-	if gpusTrackerData.Enabled == false {
+	if !gpusTrackerData.Enabled {
 		logger.Log.Printf("GPU Tracker is disabled")
 		return validGPUs, nil
 	}
 
 	result, err := gpuTracker.validateGPUsInfo(gpusTrackerData.GPUsInfo)
 	if err != nil || result != true {
-		return []int{}, fmt.Errorf("GPUs info is invalid. Please reset GPU Tracker.\n")
+		return []int{}, fmt.Errorf("GPU info mismatch: please reset GPU Tracker")
 	}
 
 	var allocatedGPUs []int
 	var unavailableGPUs []int
 	for _, gpuId := range validGPUs {
-		if gpusTrackerData.GPUsStatus[gpuId].Accessibility == SHARED_ACCESS ||
-			(gpusTrackerData.GPUsStatus[gpuId].Accessibility == EXCLUSIVE_ACCESS &&
+		if gpusTrackerData.GPUsStatus[gpuId].Accessibility == sharedAccessInt ||
+			(gpusTrackerData.GPUsStatus[gpuId].Accessibility == exclusiveAccessInt &&
 				len(gpusTrackerData.GPUsStatus[gpuId].ContainerIds) == 0) {
 			gpusTrackerData.GPUsStatus[gpuId] = gpu_status_t{
 				UUID:          gpusTrackerData.GPUsStatus[gpuId].UUID,
@@ -872,21 +794,15 @@ func (gpuTracker *gpu_tracker_t) ReserveGPUs(gpus string, containerId string) ([
 		}
 	}
 
-	err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-	if err != nil {
-		logger.Log.Printf("Failed to reserve GPUs %v, Error: %v", validGPUs, err)
-		fmt.Printf("Failed to reserve GPUs %v, Error: %v\n", validGPUs, err)
+	if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
 		return []int{}, err
 	}
 
 	if len(allocatedGPUs) > 0 {
 		logger.Log.Printf("GPUs %v allocated", allocatedGPUs)
-		fmt.Printf("GPUs %v allocated\n", allocatedGPUs)
 	}
 	if len(unavailableGPUs) > 0 {
-		logger.Log.Printf("GPUs %v are exlusive and already in use", unavailableGPUs)
-		fmt.Printf("GPUs %v are exclusive and already in use\n", unavailableGPUs)
-		return []int{}, fmt.Errorf("GPUs %v are exclusive and already in use\n", unavailableGPUs)
+		return []int{}, fmt.Errorf("GPUs %v are exclusive and already in use", unavailableGPUs)
 	}
 
 	return allocatedGPUs, nil
@@ -906,21 +822,16 @@ func (gpuTracker *gpu_tracker_t) ReleaseGPUs(containerId string) error {
 	if err != nil {
 		return err
 	}
-
 	defer lock.Unlock()
 
 	gpuTrackerInitialized, err := gpuTracker.isGPUTrackerInitialized()
 	if err != nil {
-		logger.Log.Printf("Failed to check if GPU Tracker is initialized, Error:%v", err)
-		fmt.Printf("Failed to check if GPU Tracker is initialized, Error:%v\n", err)
 		return err
 	}
 
 	if gpuTrackerInitialized {
 		gpusTrackerData, err := gpuTracker.readGPUTrackerFile()
 		if err != nil {
-			logger.Log.Printf("Failed to release GPUs used by container %v, Error: %v", containerId, err)
-			fmt.Printf("Failed to release GPUs used by container %v, Error: %v\n", containerId, err)
 			return err
 		}
 
@@ -938,15 +849,11 @@ func (gpuTracker *gpu_tracker_t) ReleaseGPUs(containerId string) error {
 			}
 		}
 
-		err = gpuTracker.writeGPUTrackerFile(gpusTrackerData)
-		if err != nil {
-			logger.Log.Printf("Failed to release GPUs used by container %v, Error: %v", containerId, err)
-			fmt.Printf("Failed to release GPUs used by container %v, Error: %v\n", containerId, err)
+		if err := gpuTracker.writeGPUTrackerFile(gpusTrackerData); err != nil {
 			return err
 		}
 
 		logger.Log.Printf("Released GPUs %v used by container %v", releasedGPUs, containerId)
-		fmt.Printf("Released GPUs %v used by container %v\n", releasedGPUs, containerId)
 	}
 
 	return nil

--- a/internal/gpu-tracker/gpu-tracker_test.go
+++ b/internal/gpu-tracker/gpu-tracker_test.go
@@ -148,13 +148,13 @@ func mockReadGPUTrackerFile() (gpu_tracker_data_t, error) {
 			0: {
 				UUID:          "0xef2c1799a1f3e2ed",
 				PartitionType: "",
-				Accessibility: 0,
+				Accessibility: sharedAccessInt,
 				ContainerIds:  []string{"container_1", "container_2"},
 			},
 			1: {
 				UUID:          "0x1234567890abcdef",
 				PartitionType: "",
-				Accessibility: 1,
+				Accessibility: exclusiveAccessInt,
 				ContainerIds:  []string{"container_1"},
 			},
 		},
@@ -211,13 +211,13 @@ func TestInterface(t *testing.T) {
 	err = gpuTracker.Disable()
 	Assert(t, err == nil, fmt.Sprintf("Disable() returned error %v", err))
 
-	err = gpuTracker.ShowStatus()
+	_, err = gpuTracker.ShowStatus()
 	Assert(t, err == nil, fmt.Sprintf("ShowStatus() returned error %v", err))
 
-	err = gpuTracker.MakeGPUsExclusive("0,1")
+	_, err = gpuTracker.MakeGPUsExclusive("0,1")
 	Assert(t, err == nil, fmt.Sprintf("MakeGPUsExclusive() returned error %v", err))
 
-	err = gpuTracker.MakeGPUsShared("0-1")
+	_, err = gpuTracker.MakeGPUsShared("0-1")
 	Assert(t, err == nil, fmt.Sprintf("MakeGPUsShared() returned error %v", err))
 
 	// Reserve Shared GPU

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -23,7 +23,7 @@ import (
 	"strings"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
-	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	gpuTracker "github.com/ROCm/container-toolkit/internal/gpu-tracker"
 	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -386,7 +386,6 @@ func (oci *oci_t) WriteSpec() error {
 
 	encoder := json.NewEncoder(file)
 	if err := encoder.Encode(oci.spec); err != nil {
-		fmt.Printf("Error encoding JSON: %s\n", err)
 		return err
 	}
 


### PR DESCRIPTION
This PR does the following fixes:-
- Add IsEnabled() to the gpu-tracker Interface as a read-only state query, enabling CLI callers to print context-appropriate messages ("already enabled", "is disabled") before calling mutating methods
- Change ShowStatus to return []GPUStatusEntry instead of printing a table directly
- Change MakeGPUsExclusive/MakeGPUsShared to return *AccessibilityResult instead of printing results directly
- Export Accessibility type with SHARED_ACCESS/EXCLUSIVE_ACCESS constants; keep internal int representation for backward-compatible JSON serialization
- Change CDI PrintSpec to return (string, error), remove prints from WriteSpec and ValidateSpec
- Move all user-facing fmt.Printf out of internal/ libraries into cmd/ CLI callers
- Libraries now return structured data and errors only — they do not print to stdout. CLI callers own all display formatting.

---
Test plan

- [x] Run amd-ctk gpu-tracker enable (fresh) — should print "GPU Tracker has been enabled"
- [x] Run amd-ctk gpu-tracker enable (again) — should print "GPU Tracker is already enabled"
- [x] Run amd-ctk gpu-tracker disable (disabled) — should print "GPU Tracker has been disabled"
- [x] Run amd-ctk gpu-tracker disable (already disabled) — should print "GPU Tracker is already disabled"
- [x] Run amd-ctk gpu-tracker status (disabled) — should print "GPU Tracker is disabled"
- [x] Run amd-ctk gpu-tracker status (enabled) — should print table with GPU info
- [x] Run amd-ctk gpu-tracker 0,1 exclusive — should print which GPUs changed
- [x] Run amd-ctk gpu-tracker reset (was enabled) — should print reset message + restart recommendation
- [x] Run amd-ctk cdi generate — should print "Generated CDI spec: ..."
- [x] Run amd-ctk cdi validate (valid) — should print "CDI spec is valid"
- [x] Run amd-ctk cdi validate (invalid) — should print "CDI spec is invalid"
- [x] Verify existing gpu-tracker.json files still deserialize correctly (backward-compatible JSON)

I have tested for all the above cases and the behaviour looks as expected.