### PR TITLE
Migrate logging from internal/logger to log/slog for amd-ctk

### DIFF
--- a/cmd/amd-ctk/main.go
+++ b/cmd/amd-ctk/main.go
@@ -18,12 +18,12 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/cdi"
-	"github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker"
+	gpuTracker "github.com/ROCm/container-toolkit/cmd/amd-ctk/gpu-tracker"
 	"github.com/ROCm/container-toolkit/cmd/amd-ctk/runtime"
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/urfave/cli/v2"
 )
 
@@ -32,6 +32,10 @@ var (
 	BuildDate = "unknown"
 	GitCommit = "none"
 )
+
+type options struct {
+	debug bool
+}
 
 func showVersion() *cli.Command {
 	showVersionCmd := cli.Command{
@@ -48,7 +52,7 @@ func showVersion() *cli.Command {
 }
 
 func main() {
-	logger.Init(false)
+	opts := options{}
 
 	// Create the top-level CLI tree
 	amdCtkCli := &cli.App{
@@ -56,6 +60,25 @@ func main() {
 		EnableBashCompletion: true,
 		Usage:                "Tool to configure AMD Container Toolkit",
 		UsageText:            "amd-ctk [command] [options]",
+		Flags: []cli.Flag{
+			&cli.BoolFlag{
+				Name:        "debug",
+				Aliases:     []string{"d"},
+				Usage:       "Enable debug output",
+				Destination: &opts.debug,
+			},
+		},
+		Before: func(c *cli.Context) error {
+			level := slog.LevelInfo
+			if opts.debug {
+				level = slog.LevelDebug
+			}
+			handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+				Level: level,
+			})
+			slog.SetDefault(slog.New(handler))
+			return nil
+		},
 	}
 
 	// Add subcommands

--- a/cmd/container-runtime/main.go
+++ b/cmd/container-runtime/main.go
@@ -17,36 +17,37 @@
 package main
 
 import (
+	"log/slog"
 	"os"
 
-	"github.com/ROCm/container-toolkit/internal/gpu-tracker"
+	gpuTracker "github.com/ROCm/container-toolkit/internal/gpu-tracker"
 	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/ROCm/container-toolkit/internal/runtime"
 )
 
 func main() {
 	logger.Init(false)
-	logger.Log.Printf("Creating ROCm container runtime with args %v", os.Args)
+	slog.Info("Creating ROCm container runtime", "args", os.Args)
 
 	rt, err := runtime.New(os.Args)
 	if err != nil {
-		logger.Log.Printf("Failed to create container runtime, err = %v", err)
+		slog.Error("Failed to create container runtime", "error", err)
 		gpuTracker, err := gpuTracker.New()
 		if err != nil {
-			logger.Log.Printf("Failed to create GPU tracker, err = %v", err)
+			slog.Error("Failed to create GPU tracker", "error", err)
 			os.Exit(1)
 		}
 		gpuTracker.ReleaseGPUs(os.Args[len(os.Args)-1])
 		os.Exit(1)
 	}
 
-	logger.Log.Printf("Running ROCm container runtime")
+	slog.Info("Running ROCm container runtime")
 	err = rt.Run()
 	if err != nil {
-		logger.Log.Printf("Failed to run container runtime, err = %v", err)
+		slog.Error("Failed to run container runtime", "error", err)
 		gpuTracker, err := gpuTracker.New()
 		if err != nil {
-			logger.Log.Printf("Failed to create GPU tracker, err = %v", err)
+			slog.Error("Failed to create GPU tracker", "error", err)
 			os.Exit(1)
 		}
 		gpuTracker.ReleaseGPUs(os.Args[len(os.Args)-1])

--- a/docs/container-runtime/cdi-guide.rst
+++ b/docs/container-runtime/cdi-guide.rst
@@ -134,3 +134,8 @@ If ``amd-ctk cdi validate`` reports errors:
 * Check that GPU devices are properly detected by the system (verify with ``rocm-smi``, ``amd-smi`` or similar tools)
 * Ensure GPU drivers are correctly installed
 * Regenerate the specification to reflect the current system state
+* Use the ``--debug`` flag for verbose output to help diagnose the issue:
+
+  .. code-block:: bash
+
+      amd-ctk --debug cdi validate

--- a/docs/container-runtime/gpu-tracker.md
+++ b/docs/container-runtime/gpu-tracker.md
@@ -166,10 +166,13 @@ Device  Node  IDs              Temp    Power  Partitions          SCLK    MCLK  
 
       > docker run --runtime=amd -itd -e AMD_VISIBLE_DEVICES=0-2 rocm/rocm-terminal bash
       d23ff3dce1839cbf8ce7ad362641ab85e80b315c319edf73b269c460e348053a
-      docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: unable to retrieve OCI runtime error (open /run/containerd/io.containerd.runtime.v2.task/moby/d23ff3dce1839cbf8ce7ad362641ab85e80b315c319edf73b269c460e348053a/log.json: no such file or directory): amd-container-runtime did not terminate successfully: exit status 1: GPUs [0 2] allocated
-      GPUs [1] are exclusive and already in use
-      Released GPUs [2 0] used by container d23ff3dce1839cbf8ce7ad362641ab85e80b315c319edf73b269c460e348053a
-      : unknown.
+      docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: unable to retrieve OCI runtime error: amd-container-runtime did not terminate successfully: exit status 1
+
+      The runtime log at /var/log/amd-container-runtime.log will contain details about the failure:
+
+      > grep -E "allocated|exclusive" /var/log/amd-container-runtime.log
+      time=... level=INFO msg="amd-container-runtime GPUs allocated" gpus=[0 2]
+      time=... level=ERROR msg="amd-container-runtime Failed to run container runtime" error="update OCI spec (add GPU devices): GPUs [1] are exclusive and already in use"
 
       > amd-ctk gpu-tracker status
       ------------------------------------------------------------------------------------------------------------------------
@@ -285,7 +288,7 @@ Device  Node  IDs              Temp    Power  Partitions          SCLK    MCLK  
 
       ```text
       > amd-ctk gpu-tracker status
-      GPUs info is invalid. Please reset GPU Tracker.
+      showing GPU status: GPU info mismatch: please reset GPU Tracker
 
       > amd-ctk gpu-tracker reset
       GPU Tracker has been reset
@@ -307,3 +310,18 @@ Device  Node  IDs              Temp    Power  Partitions          SCLK    MCLK  
       3         0x12FE4F7FDAF06B9        Shared              -
       ```
 
+## Debugging
+
+For verbose debug output when troubleshooting GPU Tracker issues, use the `--debug` (or `-d`) flag:
+
+```text
+> amd-ctk --debug gpu-tracker status
+```
+
+This prints debug-level log messages to stderr, which can help diagnose GPU enumeration or tracker state issues.
+
+For container runtime errors (e.g. exclusive GPU enforcement failures), check the runtime log:
+
+```text
+> sudo tail -f /var/log/amd-container-runtime.log
+```

--- a/docs/container-runtime/troubleshooting.rst
+++ b/docs/container-runtime/troubleshooting.rst
@@ -144,7 +144,7 @@ This applies to any run that relies on host GPU devices (e.g. ``docker run --dev
 Log File Reference
 ------------------
 
-The AMD Container Toolkit logs runtime events and errors to the following location:
+The AMD container runtime (``amd-container-runtime``) logs events and errors to the following location:
 
    **/var/log/amd-container-runtime.log**
 
@@ -157,11 +157,22 @@ You can view logs in real-time using:
 This log captures detailed interactions between Docker and the AMD container runtime, including:
 
 - Runtime initialization
-- GPU device injection
+- GPU device injection and allocation
 - OCI specification modifications
-- CDI specification usage
+- Exclusive GPU enforcement errors
 
-If you experience issues that are not easily diagnosed, refer to this log file for real-time insights and deeper debugging.
+If a container fails to start with the AMD runtime, this log will contain the specific error (e.g. ``GPUs [0] are exclusive and already in use``), even when Docker only shows a generic runtime failure message.
+
+.. note::
+
+   The ``amd-ctk`` CLI tool prints errors directly to the terminal (not to a log file). For verbose debug output from ``amd-ctk``, use the ``--debug`` (or ``-d``) flag:
+
+   .. code-block:: bash
+
+      amd-ctk --debug gpu-tracker status
+      amd-ctk --debug cdi validate
+
+   This prints debug-level messages to stderr, which can help diagnose GPU enumeration, tracker state, or CDI specification issues.
 
 Diagnostic Commands
 -------------------

--- a/internal/amdgpu/amdgpu.go
+++ b/internal/amdgpu/amdgpu.go
@@ -1,14 +1,14 @@
 /**
 # Copyright (c) Advanced Micro Devices, Inc. All rights reserved.
 #
-# Licensed under the Apache License, Version 2.0 (the \"License\");
+# Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an \"AS IS\" BASIS,
+# distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
@@ -20,6 +20,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"math"
 	"os"
 	"os/exec"
@@ -28,8 +29,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-
-	"github.com/ROCm/container-toolkit/internal/logger"
 )
 
 type DeviceInfo struct {
@@ -215,6 +214,7 @@ func GetAMDGPUWithFS(fs FileSystem, dev string) (AMDGPU, error) {
 			ret, err = strconv.ParseInt(out, base, width)
 		}
 		if err != nil {
+			slog.Debug("Failed to parse device stat", "device", dev, "value", out, "base", base, "error", err)
 			return 0
 		}
 
@@ -253,15 +253,15 @@ func GetDevIdsFromTopology(fs FileSystem, topoRootParam ...string) map[int]strin
 	renderDevIds := make(map[int]string)
 	nodeFiles, err := fs.Glob(topoRoot + "/topology/nodes/*/properties")
 	if err != nil {
-		logger.Log.Printf("glob error: %s", err)
+		slog.Warn("Failed to glob topology nodes", "error", err)
 		return renderDevIds
 	}
 
 	for _, nodeFile := range nodeFiles {
-		logger.Log.Printf("Parsing %s", nodeFile)
+		slog.Debug("Parsing topology node file", "file", nodeFile)
 		renderMinor, err := ParseTopologyProperties(fs, nodeFile, renderMinorRe)
 		if err != nil {
-			logger.Log.Printf("Error parsing render minor: %v", err)
+			slog.Debug("Error parsing render minor", "file", nodeFile, "error", err)
 			continue
 		}
 
@@ -271,7 +271,7 @@ func GetDevIdsFromTopology(fs FileSystem, topoRootParam ...string) map[int]strin
 
 		devID, err := ParseTopologyPropertiesString(fs, nodeFile, topoUniqueIdRe)
 		if err != nil {
-			logger.Log.Printf("Error parsing unique_id: %v", err)
+			slog.Debug("Error parsing unique_id", "file", nodeFile, "error", err)
 			continue
 		}
 

--- a/internal/amdgpu/amdgpu_test.go
+++ b/internal/amdgpu/amdgpu_test.go
@@ -2,22 +2,15 @@ package amdgpu
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 	"time"
 
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
-
-func init() {
-	// Initialize logger for tests
-	logger.Log = log.New(os.Stderr, "", log.LstdFlags)
-}
 
 // Mock filesystem operations
 type mockFS struct {

--- a/internal/cdi/cdi_test.go
+++ b/internal/cdi/cdi_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/stretchr/testify/assert"
 	"tags.cncf.io/container-device-interface/specs-go"
 )
@@ -49,13 +48,7 @@ func mockGetAMDGPU(dev string) (amdgpu.AMDGPU, error) {
 	return gpu, nil
 }
 
-func setup(t *testing.T) {
-	logger.Init(true)
-}
-
 func TestInterface(t *testing.T) {
-	setup(t)
-
 	spec := specs.Spec{
 		Version: "0.6.0",
 		Kind:    "amd.com/gpu",
@@ -89,7 +82,6 @@ var dummySpec = specs.Spec{
 }
 
 func TestWriteSpec(t *testing.T) {
-	setup(t)
 
 	tests := []struct {
 		name    string
@@ -159,7 +151,6 @@ func TestWriteSpec(t *testing.T) {
 }
 
 func TestWriteSpec_OverwritesExisting(t *testing.T) {
-	setup(t)
 	dir := t.TempDir()
 	specPath := filepath.Join(dir, "amd.json")
 

--- a/internal/gpu-tracker/gpu-tracker.go
+++ b/internal/gpu-tracker/gpu-tracker.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"reflect"
 	"sort"
@@ -29,7 +30,6 @@ import (
 	"time"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/gofrs/flock"
 )
 
@@ -439,7 +439,6 @@ func (gpuTracker *gpu_tracker_t) Init() error {
 		return err
 	}
 
-	logger.Log.Printf("GPU Tracker has been initialized")
 	return nil
 }
 
@@ -756,14 +755,14 @@ func (gpuTracker *gpu_tracker_t) ReserveGPUs(gpus string, containerId string) ([
 		return []int{}, err
 	}
 	if len(invalidGPUsRange) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs Ranges as they are invalid", invalidGPUsRange)
+		slog.Warn("Ignoring GPUs Ranges as they are invalid", "ranges", invalidGPUsRange)
 	}
 	if len(invalidGPUs) > 0 {
-		logger.Log.Printf("Ignoring %v GPUs as they are invalid", invalidGPUs)
+		slog.Warn("Ignoring GPUs as they are invalid", "gpus", invalidGPUs)
 	}
 
 	if !gpusTrackerData.Enabled {
-		logger.Log.Printf("GPU Tracker is disabled")
+		slog.Debug("GPU Tracker is disabled")
 		return validGPUs, nil
 	}
 
@@ -798,7 +797,7 @@ func (gpuTracker *gpu_tracker_t) ReserveGPUs(gpus string, containerId string) ([
 	}
 
 	if len(allocatedGPUs) > 0 {
-		logger.Log.Printf("GPUs %v allocated", allocatedGPUs)
+		slog.Info("GPUs allocated", "gpus", allocatedGPUs)
 	}
 	if len(unavailableGPUs) > 0 {
 		return []int{}, fmt.Errorf("GPUs %v are exclusive and already in use", unavailableGPUs)
@@ -852,7 +851,7 @@ func (gpuTracker *gpu_tracker_t) ReleaseGPUs(containerId string) error {
 			return err
 		}
 
-		logger.Log.Printf("Released GPUs %v used by container %v", releasedGPUs, containerId)
+		slog.Info("Released GPUs used by container", "gpus", releasedGPUs, "container", containerId)
 	}
 
 	return nil

--- a/internal/gpu-tracker/gpu-tracker_test.go
+++ b/internal/gpu-tracker/gpu-tracker_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
-	"github.com/ROCm/container-toolkit/internal/logger"
 )
 
 func mockIsGPUTrackerInitialized() (bool, error) {
@@ -71,8 +70,6 @@ func mockParseGPUsList(gpus string) ([]int, []string, []string, error) {
 
 	gpusInfo, err := mockGetAMDGPUs()
 	if err != nil {
-		logger.Log.Printf("Failed to get AMD GPUs info, Error: %v", err)
-		fmt.Printf("Failed to get AMD GPUs info, Error: %v\n", err)
 		return []int{}, []string{}, []string{}, err
 	}
 
@@ -85,7 +82,6 @@ func mockParseGPUsList(gpus string) ([]int, []string, []string, error) {
 
 	uuidToGPUIdMap, err := mockGetUniqueIdToDeviceIndexMap()
 	if err != nil {
-		logger.Log.Printf("Failed to get UUID to GPU Id mappings: %v", err)
 		uuidToGPUIdMap = make(map[string][]int) // Continue with empty map
 	}
 
@@ -185,13 +181,7 @@ func mockValidateGPUsInfo(map[int]amdgpu.DeviceInfo) (bool, error) {
 	return true, nil
 }
 
-func setup(t *testing.T) {
-	logger.Init(true)
-}
-
 func TestInterface(t *testing.T) {
-	setup(t)
-
 	gpuTracker := &gpu_tracker_t{
 		gpuTrackerLockFile:      "/tmp/gpu-tracker.lock",
 		isGPUTrackerInitialized: mockIsGPUTrackerInitialized,

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -17,7 +17,8 @@
 package logger
 
 import (
-	"log"
+	"io"
+	"log/slog"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -25,7 +26,6 @@ import (
 )
 
 var (
-	Log       *log.Logger
 	logdir    = "/var/log/"
 	logfile   = "amd-container-runtime.log"
 	logPrefix = "amd-container-runtime "
@@ -63,7 +63,8 @@ func SetLogDir() {
 
 		//check if the user has permission to write to this location
 		if !isWriteable(logdir) {
-			log.Fatalf("User doesn't have write permission for the specified directory: %v", logdir)
+			slog.Error("User doesn't have write permission for the specified directory", "dir", logdir)
+			os.Exit(1)
 		}
 
 		return
@@ -72,22 +73,25 @@ func SetLogDir() {
 	// Get the current user's information.
 	currentUser, err := user.Current()
 	if err != nil {
-		log.Fatalf("Failed to get current user: %v", err)
+		slog.Error("Failed to get current user", "error", err)
+		os.Exit(1)
 	}
 	// for root user, log dir is /var/log
 	if currentUser.Uid != "0" {
 		//Non-Root user, setting log directory to user's home directory
 		homeDir, err := os.UserHomeDir()
 		if err != nil {
-			log.Fatalf("Failed to get user home directory: %v", err)
+			slog.Error("Failed to get user home directory", "error", err)
+			os.Exit(1)
 		}
 		logdir = homeDir
 	}
 }
 
 func initLogger(console bool) {
+	var out io.Writer
 	if console {
-		Log = log.New(os.Stdout, logPrefix, log.Lmsgprefix)
+		out = os.Stdout
 	} else {
 		SetLogDir()
 
@@ -96,11 +100,19 @@ func initLogger(console bool) {
 		if err != nil {
 			return
 		}
-
-		Log = log.New(outfile, "", 0)
+		out = outfile
 	}
 
-	Log.SetFlags(log.LstdFlags | log.Lshortfile)
+	opts := &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(_ []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.MessageKey {
+				a.Value = slog.StringValue(logPrefix + a.Value.String())
+			}
+			return a
+		},
+	}
+	slog.SetDefault(slog.New(slog.NewTextHandler(out, opts)))
 }
 
 func Init(console bool) {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -19,12 +19,12 @@ package oci
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"strings"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
 	gpuTracker "github.com/ROCm/container-toolkit/internal/gpu-tracker"
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -180,7 +180,7 @@ func (oci *oci_t) getAMDEnv() error {
 // getSpec reads the input OCI spec file into memory
 func (oci *oci_t) getSpec() error {
 	if len(oci.origSpecPath) == 0 {
-		logger.Log.Printf("Spec path is not set")
+		slog.Warn("Spec path is not set")
 		return nil
 	}
 
@@ -219,7 +219,7 @@ func (oci *oci_t) addHook() error {
 	}
 
 	oci.spec.Hooks.CreateRuntime = append(oci.spec.Hooks.CreateRuntime, hook)
-	logger.Log.Printf("Added OCI runtime hook, %v", oci.hookPath)
+	slog.Debug("Added OCI runtime hook", "path", oci.hookPath)
 
 	return nil
 }
@@ -257,7 +257,7 @@ func (oci *oci_t) addGPUDevices() error {
 	}
 
 	if oci.isAddNoGPUs() {
-		logger.Log.Printf("No GPUs to be added to OCI spec")
+		slog.Debug("No GPUs to be added to OCI spec")
 		return nil
 	}
 
@@ -265,6 +265,8 @@ func (oci *oci_t) addGPUDevices() error {
 	if err != nil {
 		return err
 	}
+
+	slog.Info("Requested GPUs for container", "gpu_indices", oci.amdDevices)
 
 	for _, idx := range oci.amdDevices {
 		if err := addGpus(devs[idx].DrmDevices); err != nil {
@@ -332,7 +334,7 @@ func (oci *oci_t) addGPUDevice(gpu amdgpu.AMDGPU) error {
 	}
 
 	oci.spec.Linux.Resources.Devices = append(oci.spec.Linux.Resources.Devices, rdev)
-	logger.Log.Printf("Added GPU device %v to OCI spec", gpu.Path)
+	slog.Debug("Added GPU device to OCI spec", "device", gpu.Path)
 
 	return nil
 }
@@ -388,7 +390,7 @@ func (oci *oci_t) WriteSpec() error {
 		return fmt.Errorf("encoding OCI spec to %s: %w", f, err)
 	}
 
-	logger.Log.Printf("Wrote spec to %v", f)
+	slog.Debug("Wrote spec", "file", f)
 	return nil
 }
 

--- a/internal/oci/oci_test.go
+++ b/internal/oci/oci_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/ROCm/container-toolkit/internal/amdgpu"
-	"github.com/ROCm/container-toolkit/internal/logger"
 )
 
 // Constants
@@ -87,8 +86,6 @@ func mockReserveGPUs(gpus string, containerId string) ([]int, error) {
 
 		gpusInfo, err := mockGetAMDGPUs()
 		if err != nil {
-			logger.Log.Printf("Failed to get AMD GPUs info, Error: %v", err)
-			fmt.Printf("Failed to get AMD GPUs info, Error: %v\n", err)
 			return []int{}, []string{}, []string{}, err
 		}
 
@@ -101,7 +98,6 @@ func mockReserveGPUs(gpus string, containerId string) ([]int, error) {
 
 		uuidToGPUIdMap, err := mockGetUniqueIdToDeviceIndexMap()
 		if err != nil {
-			logger.Log.Printf("Failed to get UUID to GPU Id mappings: %v", err)
 			uuidToGPUIdMap = make(map[string][]int) // Continue with empty map
 		}
 
@@ -161,12 +157,7 @@ func mockReserveGPUs(gpus string, containerId string) ([]int, error) {
 	return validGPUs, err
 }
 
-func setup(t *testing.T) {
-	logger.Init(true)
-}
-
 func TestParseArgs(t *testing.T) {
-	setup(t)
 	oci := &oci_t{}
 
 	// Empty args
@@ -200,7 +191,6 @@ func TestParseArgs(t *testing.T) {
 }
 
 func TestGetAMDEnv(t *testing.T) {
-	setup(t)
 	oci := &oci_t{
 		origSpecPath:                TEST_OCI_SPEC_PATH,
 		getGPUs:                     mockGetAMDGPUs,
@@ -223,7 +213,6 @@ func TestGetAMDEnv(t *testing.T) {
 }
 
 func TestAddGPUDevice(t *testing.T) {
-	setup(t)
 	oci := &oci_t{
 		origSpecPath:                TEST_OCI_SPEC_PATH,
 		getGPUs:                     mockGetAMDGPUs,
@@ -281,8 +270,6 @@ func TestNew(t *testing.T) {
 }
 
 func TestInterface(t *testing.T) {
-	setup(t)
-
 	oci := &oci_t{
 		origSpecPath:                TEST_OCI_SPEC_PATH,
 		getGPUs:                     mockGetAMDGPUs,
@@ -325,8 +312,6 @@ func mockGetUniqueIdToDeviceIndexMap() (map[string][]int, error) {
 }
 
 func TestGetAMDEnvWithUUID(t *testing.T) {
-	setup(t)
-
 	// Test with hex UUID in AMD_VISIBLE_DEVICES
 	testSpec := `{
 		"process": {
@@ -358,8 +343,6 @@ func TestGetAMDEnvWithUUID(t *testing.T) {
 }
 
 func TestGetAMDEnvWithDockerResource(t *testing.T) {
-	setup(t)
-
 	// Test with DOCKER_RESOURCE_GPU containing hex UUIDs
 	testSpec := `{
 		"process": {
@@ -391,8 +374,6 @@ func TestGetAMDEnvWithDockerResource(t *testing.T) {
 }
 
 func TestGetAMDEnvWithMixedDevices(t *testing.T) {
-	setup(t)
-
 	// Test with mixed device indices and UUIDs (different indices)
 	testSpec := `{
 		"process": {
@@ -424,8 +405,6 @@ func TestGetAMDEnvWithMixedDevices(t *testing.T) {
 }
 
 func TestGetAMDEnvWithInvalidUUID(t *testing.T) {
-	setup(t)
-
 	// Test with invalid UUID that doesn't exist in mapping
 	testSpec := `{
 		"process": {
@@ -457,8 +436,6 @@ func TestGetAMDEnvWithInvalidUUID(t *testing.T) {
 }
 
 func TestGetAMDEnvWithDuplicateDevices(t *testing.T) {
-	setup(t)
-
 	// Test with duplicate device specification (same device via index and UUID)
 	testSpec := `{
 		"process": {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -18,11 +18,11 @@ package runtime
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
 	"syscall"
 
-	"github.com/ROCm/container-toolkit/internal/logger"
 	"github.com/ROCm/container-toolkit/internal/oci"
 )
 
@@ -81,7 +81,6 @@ func (rt *runtm) Run() error {
 			// Print updated OCI spec
 			err = rt.oci.PrintSpec()
 			if err != nil {
-				logger.Log.Printf("Failed to print runtime OCI spec, Error: %v", err)
 				return err
 			}
 		*/
@@ -91,6 +90,7 @@ func (rt *runtm) Run() error {
 		if err != nil {
 			return fmt.Errorf("write OCI spec: %w", err)
 		}
+		slog.Info("Container configured for GPU access")
 	}
 
 	// Call runc with updated oci spec
@@ -99,7 +99,8 @@ func (rt *runtm) Run() error {
 		return fmt.Errorf("unable to find runc in PATH: %w", err)
 	}
 
-	logger.Log.Printf("Running runc with args: %v, environ: %v", rt.args, os.Environ())
+	slog.Info("Launching container")
+	slog.Debug("Running runc", "args", rt.args, "environ", os.Environ())
 	err = syscall.Exec(runc, rt.args, os.Environ())
 	if err != nil {
 		return fmt.Errorf("calling runc: %w", err)


### PR DESCRIPTION
Replace the custom logger.Log (backed by standard log.Logger) with Go's structured logging (log/slog) across the project.

- Configure slog in cmd/amd-ctk with --debug flag for level control (defaults to Info on stderr)
- Configure slog in cmd/container-runtime via internal/logger.Init for file-based logging at Debug level to preserve the previous behavior where all log lines were captured
- Update internal/logger to set slog as the default logger instead of exposing a log.Logger instance
- Convert all logger.Log.Printf calls to appropriate slog levels (Info, Debug, Warn, Error) with structured key-value pairs
- Remove logger.Log references from all internal packages and tests
