### PR TITLE
Use 'failed to' prefix for top-level CLI error messages

### DIFF
--- a/cmd/amd-ctk/cdi/generate/generate.go
+++ b/cmd/amd-ctk/cdi/generate/generate.go
@@ -72,19 +72,19 @@ func validateGenOptions(c *cli.Context, genOptions *generateOptions) error {
 func performAction(c *cli.Context, genOptions *generateOptions) error {
 	cdi, err := cdi.New(genOptions.output)
 	if err != nil {
-		return fmt.Errorf("creating CDI handler: %w", err)
+		return fmt.Errorf("failed to create CDI handler: %w", err)
 	}
 
 	// Generate CDI spec
 	err = cdi.GenerateSpec()
 	if err != nil {
-		return fmt.Errorf("generating CDI spec: %w", err)
+		return fmt.Errorf("failed to generate CDI spec: %w", err)
 	}
 
 	// Write updated CDI spec
 	err = cdi.WriteSpec()
 	if err != nil {
-		return fmt.Errorf("writing CDI spec: %w", err)
+		return fmt.Errorf("failed to write CDI spec: %w", err)
 	}
 
 	fmt.Printf("Generated CDI spec: %v\n", genOptions.output)

--- a/cmd/amd-ctk/cdi/validate/validate.go
+++ b/cmd/amd-ctk/cdi/validate/validate.go
@@ -72,14 +72,14 @@ func validateValOptions(c *cli.Context, valOptions *validateOptions) error {
 func performAction(c *cli.Context, valOptions *validateOptions) error {
 	cdi, err := cdi.New(valOptions.cdiSpecPath)
 	if err != nil {
-		return fmt.Errorf("creating CDI handler: %w", err)
+		return fmt.Errorf("failed to create CDI handler: %w", err)
 	}
 
 	// Validate CDI spec
 	fmt.Printf("Validating CDI spec: %v\n", valOptions.cdiSpecPath)
 	result, err := cdi.ValidateSpec()
 	if err != nil {
-		return fmt.Errorf("validating CDI spec: %w", err)
+		return fmt.Errorf("failed to validate CDI spec: %w", err)
 	}
 	if result {
 		fmt.Println("CDI spec is valid")

--- a/cmd/amd-ctk/gpu-tracker/disable/disable.go
+++ b/cmd/amd-ctk/gpu-tracker/disable/disable.go
@@ -53,12 +53,12 @@ func validateGenOptions(c *cli.Context) error {
 func performAction(c *cli.Context) error {
 	gpuTracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	enabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("checking GPU Tracker status: %w", err)
+		return fmt.Errorf("failed to check GPU Tracker status: %w", err)
 	}
 	if !enabled {
 		fmt.Println("GPU Tracker is already disabled")
@@ -67,7 +67,7 @@ func performAction(c *cli.Context) error {
 
 	err = gpuTracker.Disable()
 	if err != nil {
-		return fmt.Errorf("disabling GPU Tracker: %w", err)
+		return fmt.Errorf("failed to disable GPU Tracker: %w", err)
 	}
 
 	fmt.Println("GPU Tracker has been disabled")

--- a/cmd/amd-ctk/gpu-tracker/enable/enable.go
+++ b/cmd/amd-ctk/gpu-tracker/enable/enable.go
@@ -53,12 +53,12 @@ func validateGenOptions(c *cli.Context) error {
 func performAction(c *cli.Context) error {
 	gpuTracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	enabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("checking GPU Tracker status: %w", err)
+		return fmt.Errorf("failed to check GPU Tracker status: %w", err)
 	}
 	if enabled {
 		fmt.Println("GPU Tracker is already enabled")
@@ -67,7 +67,7 @@ func performAction(c *cli.Context) error {
 
 	err = gpuTracker.Enable()
 	if err != nil {
-		return fmt.Errorf("enabling GPU Tracker: %w", err)
+		return fmt.Errorf("failed to enable GPU Tracker: %w", err)
 	}
 
 	fmt.Println("GPU Tracker has been enabled")

--- a/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
+++ b/cmd/amd-ctk/gpu-tracker/gpu-tracker.go
@@ -91,12 +91,12 @@ func performAction(c *cli.Context) error {
 
 	gpuTracker, err := gpuTrackerLib.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	enabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("checking GPU Tracker status: %w", err)
+		return fmt.Errorf("failed to check GPU Tracker status: %w", err)
 	}
 	if !enabled {
 		fmt.Println("GPU Tracker is disabled")
@@ -108,7 +108,7 @@ func performAction(c *cli.Context) error {
 	case "exclusive":
 		res, err = gpuTracker.MakeGPUsExclusive(gpuIDs)
 		if err != nil {
-			return fmt.Errorf("making GPUs %s exclusive: %w", gpuIDs, err)
+			return fmt.Errorf("failed to make GPUs %s exclusive: %w", gpuIDs, err)
 		}
 		if len(res.Changed) > 0 {
 			fmt.Printf("GPUs %v have been made exclusive\n", res.Changed)
@@ -119,7 +119,7 @@ func performAction(c *cli.Context) error {
 	case "shared":
 		res, err = gpuTracker.MakeGPUsShared(gpuIDs)
 		if err != nil {
-			return fmt.Errorf("making GPUs %s shared: %w", gpuIDs, err)
+			return fmt.Errorf("failed to make GPUs %s shared: %w", gpuIDs, err)
 		}
 		if len(res.Changed) > 0 {
 			fmt.Printf("GPUs %v have been made shared\n", res.Changed)

--- a/cmd/amd-ctk/gpu-tracker/initialize/initialize.go
+++ b/cmd/amd-ctk/gpu-tracker/initialize/initialize.go
@@ -54,12 +54,12 @@ func validateGenOptions(c *cli.Context) error {
 func performAction(c *cli.Context) error {
 	gpuTracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	err = gpuTracker.Init()
 	if err != nil {
-		return fmt.Errorf("initializing GPU Tracker: %w", err)
+		return fmt.Errorf("failed to initialize GPU Tracker: %w", err)
 	}
 
 	return nil

--- a/cmd/amd-ctk/gpu-tracker/release/release.go
+++ b/cmd/amd-ctk/gpu-tracker/release/release.go
@@ -64,13 +64,13 @@ func performAction(c *cli.Context) error {
 
 	gpuTracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	containerId := c.Args().Get(0)
 	err = gpuTracker.ReleaseGPUs(containerId)
 	if err != nil {
-		return fmt.Errorf("releasing GPUs for container %s: %w", containerId, err)
+		return fmt.Errorf("failed to release GPUs for container %s: %w", containerId, err)
 	}
 
 	return nil

--- a/cmd/amd-ctk/gpu-tracker/reset/reset.go
+++ b/cmd/amd-ctk/gpu-tracker/reset/reset.go
@@ -53,17 +53,17 @@ func validateGenOptions(c *cli.Context) error {
 func performAction(c *cli.Context) error {
 	gpuTracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	wasEnabled, err := gpuTracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("checking GPU Tracker status: %w", err)
+		return fmt.Errorf("failed to check GPU Tracker status: %w", err)
 	}
 
 	err = gpuTracker.Reset()
 	if err != nil {
-		return fmt.Errorf("resetting GPU Tracker: %w", err)
+		return fmt.Errorf("failed to reset GPU Tracker: %w", err)
 	}
 
 	fmt.Println("GPU Tracker has been reset")

--- a/cmd/amd-ctk/gpu-tracker/status/status.go
+++ b/cmd/amd-ctk/gpu-tracker/status/status.go
@@ -54,12 +54,12 @@ func validateGenOptions(c *cli.Context) error {
 func performAction(c *cli.Context) error {
 	tracker, err := gpuTracker.New()
 	if err != nil {
-		return fmt.Errorf("creating GPU tracker: %w", err)
+		return fmt.Errorf("failed to create GPU Tracker: %w", err)
 	}
 
 	enabled, err := tracker.IsEnabled()
 	if err != nil {
-		return fmt.Errorf("checking GPU Tracker status: %w", err)
+		return fmt.Errorf("failed to check GPU Tracker status: %w", err)
 	}
 	if !enabled {
 		fmt.Println("GPU Tracker is disabled")
@@ -68,7 +68,7 @@ func performAction(c *cli.Context) error {
 
 	entries, err := tracker.ShowStatus()
 	if err != nil {
-		return fmt.Errorf("showing GPU status: %w", err)
+		return fmt.Errorf("failed to show GPU Tracker status: %w", err)
 	}
 
 	fmt.Println(strings.Repeat("-", 120))


### PR DESCRIPTION
Gerund-style errors (e.g. "creating X: ...") are appropriate for internal helpers but ambiguous at the CLI boundary where the user sees them directly. Switch to "failed to <verb>" for all top-level errors returned from cmd/ action handlers.
