### PR TITLE
Rename docs header from Instinct to GPU Systems and Infrastructure

### DIFF
--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,4 +1,4 @@
-rocm-docs-core==1.15.0
+rocm-docs-core==1.33.1
 sphinx-reredirects
 sphinxcontrib.datatemplates==0.11.0
 Sphinx-Substitution-Extensions==2025.1.2

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -193,7 +193,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.15.0
+rocm-docs-core==1.33.1
     # via -r requirements.in
 rpds-py==0.23.1
     # via


### PR DESCRIPTION
## Summary
- Bump `rocm-docs-core` from 1.15.0 to 1.34.0
- Picks up upstream header rename from "Instinct" to "GPU Systems and Infrastructure" (aligned with SW Product Management)

## Test plan
- [x] Verify docs build succeeds
- [x] Confirm RTD page header shows "GPU Systems and Infrastructure"