### PR TITLE
Add Ubuntu 26.04 (resolute) Debian package build support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,14 @@ export ${BUILD_VER_ENV}
 
 # 22.04 - jammy
 # 24.04 - noble
+# 26.04 - resolute
 UBUNTU_VERSION ?= jammy
 UBUNTU_VERSION_NUMBER = 22.04
 ifeq (${UBUNTU_VERSION}, noble)
 UBUNTU_VERSION_NUMBER = 24.04
+endif
+ifeq (${UBUNTU_VERSION}, resolute)
+UBUNTU_VERSION_NUMBER = 26.04
 endif
 
 DEBIAN_VERSION := "1.3.0"

--- a/tools/deb/base-image/entrypoint.sh
+++ b/tools/deb/base-image/entrypoint.sh
@@ -22,6 +22,12 @@ sysctl -w vm.max_map_count=262144
 if [[ -n "${USER_NAME:-}" && -n "${USER_UID:-}" && -n "${USER_GID:-}" ]]; then
 	echo "Creating user ${USER_NAME} with UID=${USER_UID}, GID=${USER_GID}..."
 
+	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"
+	if [[ -n "$existing_user" && "$existing_user" != "$USER_NAME" ]]; then
+		echo "Removing existing user $existing_user with UID=$USER_UID..."
+		userdel -r "$existing_user" || userdel "$existing_user"
+	fi
+
 	if ! getent group "$USER_GID" >/dev/null; then
 		groupadd -g "$USER_GID" "$USER_NAME"
 	fi

--- a/tools/deb/base-image/entrypoint.sh
+++ b/tools/deb/base-image/entrypoint.sh
@@ -22,7 +22,7 @@ sysctl -w vm.max_map_count=262144
 if [[ -n "${USER_NAME:-}" && -n "${USER_UID:-}" && -n "${USER_GID:-}" ]]; then
 	echo "Creating user ${USER_NAME} with UID=${USER_UID}, GID=${USER_GID}..."
 
-	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"
+	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)" || true
 	if [[ -n "$existing_user" && "$existing_user" != "$USER_NAME" ]]; then
 		echo "Removing existing user $existing_user with UID=$USER_UID..."
 		userdel -r "$existing_user" || userdel "$existing_user"


### PR DESCRIPTION
Closes #133.

## Motivation

Add Ubuntu 26.04 support.

## Technical Details

Map the UBUNTU_VERSION codename "resolute" to version number 26.04 so `make pkg-deb UBUNTU_VERSION=resolute` produces a 26.04-tagged package, alongside the existing jammy (22.04) and noble (24.04) targets.

The Ubuntu 26.04 base image ships a default non-root user occupying UID 1000, which collides with the host UID the build entrypoint tries to recreate. Detect and remove any pre-existing user holding the requested UID before creating the build user. This is a no-op on 22.04/24.04 images, which have no such default user.

## Test Plan

- Build and install locally on Ubuntu 26.04 system with AMD Radeon RX 7800 XT
- Run `amd-ctk` and generate both CDI specification and Docker runtime configuration
- Test with Docker using `AMD_VISIBLE_DEVICES=all` and `--gpus all`

## Test Result

```shell
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ sudo apt install ./amd-container-toolkit_26.04_amd64.deb
[sudo: authenticate] Password:
Note, selecting 'amd-container-toolkit' instead of './amd-container-toolkit_26.04_amd64.deb'
Upgrading:
  amd-container-toolkit

Summary:
  Upgrading: 1, Installing: 0, Removing: 0, Not Upgrading: 58
  Download size: 0 B / 4,661 kB
  Space needed: 0 B / 202 GB available

Get:1 /home/jwhitleywork/sandbox/PERSONAL/container-toolkit/bin/amd-container-toolkit_26.04_amd64.deb amd-container-toolkit amd64 1.3.0~26.04 [4,661 kB]
(Reading database… 240517 files and directories currently installed.)
Preparing to unpack …/amd-container-toolkit_26.04_amd64.deb…
Updated the docker config file
Please restart docker daemon
Checking for AMD GPU driver...
AMD GPU driver found.
Unpacking amd-container-toolkit (1.3.0~26.04) over (1.3.0~24.04)…
Setting up amd-container-toolkit (1.3.0~26.04)…
Notice: Download is performed unsandboxed as root as file '/home/jwhitleywork/sandbox/PERSONAL/container-toolkit/bin/amd-container-toolkit_26.04_amd64.deb' couldn\'t be accessed by user '_apt'. - pkgAcquire::Run (13: Permission denied)
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ sudo amd-ctk cdi generate --output=/etc/cdi/amd.json
sudo amd-ctk cdi validate --path=/etc/cdi/amd.json
Generated CDI spec: /etc/cdi/amd.json
Validating CDI spec: /etc/cdi/amd.json
CDI spec is valid
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ sudo amd-ctk runtime configure
sudo systemctl restart docker
Loading configuration from: /etc/docker/daemon.json
Updated the config file: /etc/docker/daemon.json
Please restart docker daemon
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ docker run --rm --runtime=amd -e AMD_VISIBLE_DEVICES=all rocm/rocm-terminal rocm-smi
Unable to find image 'rocm/rocm-terminal:latest' locally
latest: Pulling from rocm/rocm-terminal
4f4fb700ef54: Pull complete 
6d3e0ad5399b: Pull complete
df933558dd3d: Pull complete 
b6457c4e1a2e: Pull complete 
30a9c22ae099: Pull complete 
dde23d29fd4b: Pull complete 
74a6f5c7f5b1: Pull complete 
Digest: sha256:72b323c5d56c511ea75f7353d0fee04e637390dd4874d414020284627a658014
Status: Downloaded newer image for rocm/rocm-terminal:latest


=========================================== ROCm System Management Interface ===========================================
===================================================== Concise Info =====================================================
Device  Node  IDs              Temp    Power   Partitions          SCLK  MCLK     Fan  Perf  PwrCap       VRAM%  GPU%  
              (DID,     GUID)  (Edge)  (Avg)   (Mem, Compute, ID)                                                      
========================================================================================================================
0       1     0x747e,   58278  63.0°C  68.0W   N/A, N/A, 0         0Mhz  456Mhz   0%   auto  220.0W       6%     0%    
1       2     0x13c0,   2354   42.0°C  0.016W  N/A, N/A, 0         None  3000Mhz  0%   auto  Unsupported  0%     0%
========================================================================================================================
================================================= End of ROCm SMI Log ==================================================
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ amd-ctk cdi list
Found 2 AMD GPU devices
amd.com/gpu=all
amd.com/gpu=0
  /dev/dri/renderD128
amd.com/gpu=1
  /dev/dri/renderD129
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ amd-ctk gpu list
Found 2 AMD GPU devices
---------------------------------------------------------------------------
GPU Id    UUID                     DRM Devices                             
---------------------------------------------------------------------------
0         0x2A2BB0D4EF1574EC       /dev/dri/renderD128                     
1         0x0                      /dev/dri/renderD129                     
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ docker run --rm --runtime=amd --gpus all rocm/rocm-terminal rocm-smi


=========================================== ROCm System Management Interface ===========================================
===================================================== Concise Info =====================================================
Device  Node  IDs              Temp    Power   Partitions          SCLK  MCLK     Fan  Perf  PwrCap       VRAM%  GPU%  
              (DID,     GUID)  (Edge)  (Avg)   (Mem, Compute, ID)                                                      
========================================================================================================================
0       1     0x747e,   58278  63.0°C  68.0W   N/A, N/A, 0         0Mhz  456Mhz   0%   auto  220.0W       6%     0%    
1       2     0x13c0,   2354   42.0°C  0.016W  N/A, N/A, 0         None  3000Mhz  0%   auto  Unsupported  0%     0%
========================================================================================================================
================================================= End of ROCm SMI Log ==================================================
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ amd-ctk cdi list
Found 2 AMD GPU devices
amd.com/gpu=all
amd.com/gpu=0
  /dev/dri/renderD128
amd.com/gpu=1
  /dev/dri/renderD129
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ amd-ctk gpu list
Found 2 AMD GPU devices
---------------------------------------------------------------------------
GPU Id    UUID                     DRM Devices                             
---------------------------------------------------------------------------
0         0x2A2BB0D4EF1574EC       /dev/dri/renderD128                     
1         0x0                      /dev/dri/renderD129                     
jwhitleywork@amd-monster:~/sandbox/PERSONAL/container-toolkit/bin$ docker run --rm --runtime=amd --gpus all rocm/rocm-terminal rocm-smi


=========================================== ROCm System Management Interface ===========================================
===================================================== Concise Info =====================================================
Device  Node  IDs              Temp    Power   Partitions          SCLK  MCLK     Fan  Perf  PwrCap       VRAM%  GPU%
              (DID,     GUID)  (Edge)  (Avg)   (Mem, Compute, ID)
========================================================================================================================
0       1     0x747e,   58278  43.0°C  16.0W   N/A, N/A, 0         0Mhz  96Mhz    0%   auto  220.0W       6%     0%
1       2     0x13c0,   2354   42.0°C  0.009W  N/A, N/A, 0         None  3000Mhz  0%   auto  Unsupported  0%     0%
========================================================================================================================
================================================= End of ROCm SMI Log ==================================================

```

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.
