### PR TITLE
Document Ubuntu 26.04 support for 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For comprehensive documentation including installation, configuration, CDI, Swar
 
 ## Requirements
 
-- Ubuntu 22.04 or 24.04, or RHEL/CentOS 9
+- Ubuntu 22.04, 24.04, or 26.04, or RHEL/CentOS 9
 - Docker version 25 or later
 - All `amd-ctk runtime configure` commands should be run as root/sudo
 

--- a/docs/container-runtime/release-notes.rst
+++ b/docs/container-runtime/release-notes.rst
@@ -14,7 +14,7 @@ Compatibility Matrix
      - Supported OS
    * - 1.3.0
      - 25.0+
-     - Ubuntu 22.04, Ubuntu 24.04
+     - Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
    * - 1.2.0
      - 25.0+ 
      - Ubuntu 22.04, Ubuntu 24.04

--- a/docs/container-runtime/requirements.rst
+++ b/docs/container-runtime/requirements.rst
@@ -7,6 +7,7 @@ Supported Operating Systems
 ---------------------------
 - Ubuntu 22.04 LTS (Jammy Jellyfish)
 - Ubuntu 24.04 LTS (Noble Numbat)
+- Ubuntu 26.04 LTS (Resolute Raccoon)
 - RHEL 9.5
 
 .. note::


### PR DESCRIPTION
## Summary

Ubuntu 26.04 (Resolute) packages are already published for 1.3.0 on `repo.radeon.com` and install cleanly, but the docs still listed only 22.04 and 24.04. This closes that gap.

- `docs/container-runtime/requirements.rst`: add `Ubuntu 26.04 LTS (Resolute Raccoon)` to Supported Operating Systems.
- `docs/container-runtime/release-notes.rst`: the 1.3.0 compatibility matrix row now reads `Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04`. Rows for 1.0.0 through 1.2.0 are unchanged, those releases were never built for 26.04.
- `README.md`: Requirements line now includes 26.04.

Docs only, 3 files, +3/-2. No version bump. 26.04 support came from the build matrix addition in #134, not a code change, and the published package is already versioned `1.3.0~26.04`.

## Validation

Verified on a real MI308X (VFIO passthrough to an Ubuntu 26.04 guest, Docker 29.6.2) using the package installed by following the Quick Start Guide verbatim, which resolves the repo via `$VERSION_CODENAME` and pulled `amd-container-toolkit 1.3.0~26.04` (`v1.3.0`, commit `5cba0a1`):

- `amd-ctk version`, `amd-ctk gpu list`
- `amd-ctk cdi generate` / `validate` / `list`
- CDI injection: `--device amd.com/gpu=all`, `--device amd.com/gpu=0`, and Docker 29 native `--gpus all`
- OCI runtime injection: `--runtime=amd` with `AMD_VISIBLE_DEVICES`, running `rocminfo` and `amd-smi` in-container
- GPU Tracker: enable, allocation tracking, exclusive enforcement, auto-release on container removal, reset, disable

## Test plan

- [ ] Confirm the compatibility matrix renders correctly in the built docs. The change is text inside an existing cell, the `list-table` still has 3 cells per row.
- [ ] Confirm no other doc declares supported OS versions. I grepped `.rst`/`.md`; remaining 22.04/24.04 hits are historical matrix rows, the v1.0.0 highlight line, and `rocm/dev-ubuntu-24.04` container image names.