### PR TITLE
Sync Ubuntu 26.04 support to release/1.3.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,10 +40,14 @@ export ${BUILD_VER_ENV}
 
 # 22.04 - jammy
 # 24.04 - noble
+# 26.04 - resolute
 UBUNTU_VERSION ?= jammy
 UBUNTU_VERSION_NUMBER = 22.04
 ifeq (${UBUNTU_VERSION}, noble)
 UBUNTU_VERSION_NUMBER = 24.04
+endif
+ifeq (${UBUNTU_VERSION}, resolute)
+UBUNTU_VERSION_NUMBER = 26.04
 endif
 
 DEBIAN_VERSION := "1.3.0"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ For comprehensive documentation including installation, configuration, CDI, Swar
 
 ## Requirements
 
-- Ubuntu 22.04 or 24.04, or RHEL/CentOS 9
+- Ubuntu 22.04, 24.04, or 26.04, or RHEL/CentOS 9
 - Docker version 25 or later
 - All `amd-ctk runtime configure` commands should be run as root/sudo
 

--- a/docs/container-runtime/release-notes.rst
+++ b/docs/container-runtime/release-notes.rst
@@ -14,7 +14,7 @@ Compatibility Matrix
      - Supported OS
    * - 1.3.0
      - 25.0+
-     - Ubuntu 22.04, Ubuntu 24.04
+     - Ubuntu 22.04, Ubuntu 24.04, Ubuntu 26.04
    * - 1.2.0
      - 25.0+ 
      - Ubuntu 22.04, Ubuntu 24.04

--- a/docs/container-runtime/requirements.rst
+++ b/docs/container-runtime/requirements.rst
@@ -7,6 +7,7 @@ Supported Operating Systems
 ---------------------------
 - Ubuntu 22.04 LTS (Jammy Jellyfish)
 - Ubuntu 24.04 LTS (Noble Numbat)
+- Ubuntu 26.04 LTS (Resolute Raccoon)
 - RHEL 9.5
 
 .. note::

--- a/tools/deb/base-image/entrypoint.sh
+++ b/tools/deb/base-image/entrypoint.sh
@@ -22,6 +22,12 @@ sysctl -w vm.max_map_count=262144
 if [[ -n "${USER_NAME:-}" && -n "${USER_UID:-}" && -n "${USER_GID:-}" ]]; then
 	echo "Creating user ${USER_NAME} with UID=${USER_UID}, GID=${USER_GID}..."
 
+	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"
+	if [[ -n "$existing_user" && "$existing_user" != "$USER_NAME" ]]; then
+		echo "Removing existing user $existing_user with UID=$USER_UID..."
+		userdel -r "$existing_user" || userdel "$existing_user"
+	fi
+
 	if ! getent group "$USER_GID" >/dev/null; then
 		groupadd -g "$USER_GID" "$USER_NAME"
 	fi

--- a/tools/deb/base-image/entrypoint.sh
+++ b/tools/deb/base-image/entrypoint.sh
@@ -22,7 +22,7 @@ sysctl -w vm.max_map_count=262144
 if [[ -n "${USER_NAME:-}" && -n "${USER_UID:-}" && -n "${USER_GID:-}" ]]; then
 	echo "Creating user ${USER_NAME} with UID=${USER_UID}, GID=${USER_GID}..."
 
-	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)"
+	existing_user="$(getent passwd "$USER_UID" | cut -d: -f1)" || true
 	if [[ -n "$existing_user" && "$existing_user" != "$USER_NAME" ]]; then
 		echo "Removing existing user $existing_user with UID=$USER_UID..."
 		userdel -r "$existing_user" || userdel "$existing_user"


### PR DESCRIPTION
## Summary

Backports Ubuntu 26.04 (Resolute) support from `main` to the 1.3 release line. `release/1.3.x` currently has neither the build support nor the docs, so it cannot produce a 26.04 package even though `1.3.0~26.04` is already published on `repo.radeon.com`.

Three commits cherry-picked cleanly, no conflicts, original authorship preserved:

| Commit | Source | Change |
| --- | --- | --- |
| `Add Ubuntu 26.04 (resolute) Debian package build support` | #134 | Map `UBUNTU_VERSION=resolute` to `26.04`; remove a pre-existing user occupying the requested UID in the build entrypoint |
| `Guard UID lookup so build entrypoint works without a default UID 1000 user` | #134 | `|| true` on the `getent passwd` lookup so the entrypoint does not abort under `set -euo pipefail` on 22.04/24.04 bases |
| `Document Ubuntu 26.04 support for 1.3.0` | #137 | Supported OS list, 1.3.0 compatibility matrix row, README requirements |

5 files, +13/-2.

## Verification

- `Makefile` and `tools/deb/base-image/entrypoint.sh` are byte-identical to `main` after the cherry-picks.
- The three docs files are byte-identical to the #137 branch.
- The underlying package was validated on a real MI308X (VFIO passthrough to an Ubuntu 26.04 guest, Docker 29.6.2): CDI generate/validate/list, CDI injection via `--device amd.com/gpu` and Docker 29 native `--gpus`, OCI runtime injection via `--runtime=amd` with `AMD_VISIBLE_DEVICES` running `rocminfo`/`amd-smi`, and GPU Tracker enable/alloc/exclusive-enforcement/auto-release/reset.

## Test plan

- [ ] `make pkg-deb UBUNTU_VERSION=resolute` produces a `26.04`-tagged package on this branch.
- [ ] `make pkg-deb UBUNTU_VERSION=jammy` and `UBUNTU_VERSION=noble` still build, confirming the entrypoint guard is a no-op there.
- [ ] Compatibility matrix renders correctly in the built docs.

## Note

Merge #137 into `main` first if you want `main` and `release/1.3.x` to stay consistent, since this PR carries that docs commit.