### PR TITLE
Generate llms files with rocm_docs_generate_llms

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ html_theme = "rocm_docs_theme"
 html_theme_options = {
     "flavor": "instinct",
     "link_main_doc": True,
+    "use_download_button": True,
     # Add any additional theme options here
 }
 extensions = [
@@ -56,6 +57,11 @@ extensions = [
 external_toc_path = "./sphinx/_toc.yml"
 
 exclude_patterns = ['.venv']
+
+# Generate llms.txt and llms-full.txt after each build (the llms.txt standard,
+# https://llmstxt.org/). See the rocm-docs-core guide:
+# https://rocm.docs.amd.com/projects/rocm-docs-core/en/latest/user_guide/llms.html
+rocm_docs_generate_llms = True
 
 # Add the following replacements to every RST file.
 rst_prolog = f"""

--- a/docs/sphinx/requirements.in
+++ b/docs/sphinx/requirements.in
@@ -1,4 +1,4 @@
-rocm-docs-core==1.33.1
+rocm-docs-core[llms]==1.38.0
 sphinx-reredirects
 sphinxcontrib.datatemplates==0.11.0
 Sphinx-Substitution-Extensions==2025.1.2

--- a/docs/sphinx/requirements.txt
+++ b/docs/sphinx/requirements.txt
@@ -54,6 +54,7 @@ docutils==0.21.2
     #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinx-markdown-builder
     #   sphinx-substitution-extensions
 exceptiongroup==1.2.2
     # via ipython
@@ -193,7 +194,7 @@ requests==2.32.3
     # via
     #   pygithub
     #   sphinx
-rocm-docs-core==1.33.1
+rocm-docs-core[llms]==1.38.0
     # via -r requirements.in
 rpds-py==0.23.1
     # via
@@ -218,6 +219,7 @@ sphinx==8.1.3
     #   sphinx-copybutton
     #   sphinx-design
     #   sphinx-external-toc
+    #   sphinx-markdown-builder
     #   sphinx-notfound-page
     #   sphinx-reredirects
     #   sphinx-substitution-extensions
@@ -230,6 +232,8 @@ sphinx-copybutton==0.5.2
 sphinx-design==0.6.1
     # via rocm-docs-core
 sphinx-external-toc==1.0.1
+    # via rocm-docs-core
+sphinx-markdown-builder==0.6.10
     # via rocm-docs-core
 sphinx-notfound-page==1.1.0
     # via rocm-docs-core
@@ -258,7 +262,9 @@ sqlalchemy==2.0.38
 stack-data==0.6.3
     # via ipython
 tabulate==0.9.0
-    # via jupyter-cache
+    # via
+    #   jupyter-cache
+    #   sphinx-markdown-builder
 tomli==2.2.1
     # via sphinx
 tornado==6.4.2


### PR DESCRIPTION
## Motivation

Enable llms.txt / llms-full.txt generation for the AMD Container Toolkit docs, so the site publishes machine-readable documentation following the llms.txt standard (https://llmstxt.org/). This aligns the project with the shared approach used across the Instinct documentation set (k8s-device-plugin, instinct-docs), using the built-in support in rocm-docs-core.

## Technical Details

- Enable generation via rocm_docs_generate_llms = True in docs/conf.py, which produces both llms.txt and llms-full.txt from the resolved doctree at build time.
- Add use_download_button: True to html_theme_options for the per-page Markdown download button.
- Bump rocm-docs-core from 1.33.1 to 1.38.0 and add the [llms] extra in docs/sphinx/requirements.in; regenerate requirements.txt (Python 3.10, matching .readthedocs.yaml), which pulls in sphinx-markdown-builder. Existing pins (sphinxcontrib.datatemplates, Sphinx-Substitution-Extensions, sphinx-reredirects) are preserved.

Uses rocm-docs-core 1.38.0 rather than the latest 1.39.0: the published 1.39.0 wheel ships a malformed projects.yaml that breaks the build (already fixed upstream on develop, pending a patch release).

## Test Plan

- Regenerated docs/sphinx/requirements.txt with pip-compile under Python 3.10; confirmed the [llms] extra and all existing dependencies resolve.
- Ran a full sphinx-build -b html in a clean python:3.10-slim container with the pinned requirements, reproducing the Read the Docs environment.
- Verified llms.txt and llms-full.txt are generated and inspected their content.

## Test Result

Build succeeds (build succeeded, 36 warnings) and logs Wrote llms.txt and llms-full.txt. Generated llms.txt (1.5 KB) indexes all pages; llms-full.txt (94 KB) has correct per-page sections with prose filtering. The 36 warnings are pre-existing intersphinx 404s (unreachable inventory URLs), unrelated to this change.

## Submission Checklist

- [x] Look over the contributing guidelines at https://github.com/ROCm/ROCm/blob/develop/CONTRIBUTING.md#pull-requests.